### PR TITLE
I98 - use namespaces and don't attach packages

### DIFF
--- a/app.R
+++ b/app.R
@@ -1,8 +1,4 @@
 #!/usr/bin/env Rscript
-library(shiny)
-library(shinyjs)
-library(shinycssloaders)
-
 source("src/helpers.R")
 
 # Server (alphabetical)
@@ -32,5 +28,5 @@ source("src/ui/working_set_section.R")
 options(shiny.autoreload = TRUE, shiny.autoreload.pattern = glob2rx("**/*.R"))
 options(shiny.maxRequestSize = 30*1024^2)
 
-addResourcePath('images', file.path('images'))
-runApp("src", port = 8080)
+shiny::addResourcePath('images', file.path('images'))
+shiny::runApp("src", port = 8080)

--- a/bootstrap.R
+++ b/bootstrap.R
@@ -11,3 +11,4 @@ install.packages("ggplot2")
 
 devtools::install_github('andrewsali/shinycssloaders')
 devtools::install_github("mrc-ide/first90")
+devtools::install_github("mrc-ide/eppasm")

--- a/src/server.R
+++ b/src/server.R
@@ -1,18 +1,16 @@
-library(shiny)
-
 server <- function(input, output, session) {
     # State
-    workingSet <- reactiveValues()
+    workingSet <- shiny::reactiveValues()
     workingSet$name <- NULL
     workingSet$notes <- NULL
     workingSet$creation_error <- NULL
     workingSet$editing <- FALSE
 
-    surveyAndProgramData <- reactiveValues()
+    surveyAndProgramData <- shiny::reactiveValues()
     surveyAndProgramData$survey <- NULL
     surveyAndProgramData$program_wide <- NULL
 
-    spectrumFilesState <- reactiveValues()
+    spectrumFilesState <- shiny::reactiveValues()
     spectrumFilesState$dataSets <- list()
     spectrumFilesState$country <- NULL
 
@@ -28,7 +26,7 @@ server <- function(input, output, session) {
     handleSave(input, output, workingSet, spectrumFilesState, surveyAndProgramData)
     enableNavLinks(input, output, spectrumFilesState, modelRunState)
 
-    output$modal <- reactive({
+    output$modal <- shiny::reactive({
         if (loadState$state$uploadRequested) {
             "loadDigest"
         } else if (workingSet$editing) {
@@ -37,5 +35,5 @@ server <- function(input, output, session) {
             NULL
         }
     })
-    outputOptions(output, "modal", suspendWhenHidden = FALSE)
+    shiny::outputOptions(output, "modal", suspendWhenHidden = FALSE)
 }

--- a/src/server/model_outputs.R
+++ b/src/server/model_outputs.R
@@ -37,7 +37,7 @@ fitModel <- function(survey_data, program_data, fp){
     prg_dat <- prepareProgramInput(program_data)
 
     # We create the likelihood data
-    likdat <- prepare_hts_likdat(dat, prg_dat, fp)
+    likdat <- first90::prepare_hts_likdat(dat, prg_dat, fp)
 
     # Starting parameters
     theta0 <- c(rep(log(0.1), 18), # Males: log of testing rates in 2005, 2010, and 2015
@@ -47,13 +47,13 @@ fitModel <- function(survey_data, program_data, fp){
                 log(0.2),   # Fractor testing among diagnosed, on ART
                 rep(log(0.5), 2)) # Rate ratio for testing in the 25+ age group
 
-    ll_hts(theta0, fp, likdat)
+    first90::ll_hts(theta0, fp, likdat)
 
     opt <- optim(theta0, ll_hts, fp = fp, likdat = likdat, method="BFGS",
     control=list(fnscale = -1, trace=4, REPORT=1, maxit=150))
 
     round(exp(opt$par[1:36]), 3)
-    fp <- create_hts_param(opt$par, fp)
+    fp <- first90::create_hts_param(opt$par, fp)
 
     return(list("fp" = fp, "likdat" = likdat))
 }
@@ -66,7 +66,7 @@ outEverTest <- function(fp, mod) {
                                 sex = c("both", "female", "male"),
                                 hivstatus = c("all", "negative", "positive"))
 
-    out_evertest$value <- evertest(mod, fp, add_ss_indices(out_evertest, fp$ss))
+    out_evertest$value <- first90::evertest(mod, fp, first90::add_ss_indices(out_evertest, fp$ss))
 
     out_evertest
 }
@@ -79,7 +79,7 @@ numberTested <- function(fp, mod) {
                             sex="both",
                             hivstatus='all')
 
-    out_nbtest$value <- number_tests(mod, fp, add_ss_indices(out_nbtest, fp$ss))$tests
+    out_nbtest$value <- first90::number_tests(mod, fp, first90::add_ss_indices(out_nbtest, fp$ss))$tests
 
     out_nbtest
 }
@@ -92,7 +92,7 @@ numberTestedPositive <- function(fp, mod) {
                                 sex="both",
                                 hivstatus='positive')
 
-    out_nbtest_pos$value <- number_tests(mod, fp, add_ss_indices(out_nbtest_pos, fp$ss))$tests
+    out_nbtest_pos$value <- first90::number_tests(mod, fp, first90::add_ss_indices(out_nbtest_pos, fp$ss))$tests
 
     out_nbtest_pos
 }
@@ -144,7 +144,7 @@ first90Data <- function(fp, mod) {
                         sex = c("both", "female", "male"),
                         hivstatus = 'positive')
 
-    out$value <- diagnosed(mod, fp, add_ss_indices(out, fp$ss))
+    out$value <- first90::diagnosed(mod, fp, first90::add_ss_indices(out, fp$ss))
 
     out_art <- data.frame(year = 1970:2022,
                             outcome = "artcov",

--- a/src/server/model_outputs.R
+++ b/src/server/model_outputs.R
@@ -49,7 +49,7 @@ fitModel <- function(survey_data, program_data, fp){
 
     first90::ll_hts(theta0, fp, likdat)
 
-    opt <- optim(theta0, ll_hts, fp = fp, likdat = likdat, method="BFGS",
+    opt <- optim(theta0, first90::ll_hts, fp = fp, likdat = likdat, method="BFGS",
     control=list(fnscale = -1, trace=4, REPORT=1, maxit=150))
 
     round(exp(opt$par[1:36]), 3)

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -1,17 +1,15 @@
-library(shiny)
-library(first90)
 library(purrr)
 
 modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
-    state <- reactiveValues()
+    state <- shiny::reactiveValues()
     state$state <- "not_run"
 
-    observeEvent(input$runModel, {
+    shiny::observeEvent(input$runModel, {
 
         # the model fitting code expects survey data as a data table and program data as a data frame
         # it could presumably be re-written to deal with survey data as a data frame but for now we're just
         # converting survey data to the expected format
-        surveyAsDataTable <- as.data.table(surveyAndProgramData$survey, keep.rownames = TRUE)
+        surveyAsDataTable <- data.table::as.data.table(surveyAndProgramData$survey, keep.rownames = TRUE)
 
         out <- fitModel(surveyAsDataTable, surveyAndProgramData$program(), spectrumFilesState$combinedData())
 
@@ -28,34 +26,34 @@ modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
         state$state <- "finished"
     })
 
-    output$modelRunState <- reactive({ state$state })
-    outputOptions(output, "modelRunState", suspendWhenHidden = FALSE)
+    output$modelRunState <- shiny::reactive({ state$state })
+    shiny::outputOptions(output, "modelRunState", suspendWhenHidden = FALSE)
 
     state
 }
 
 plotModelRunResults <- function(output, surveyAsDataTable, likdat, fp, mod, out_evertest) {
-    output$outputs_totalNumberOfTests <- renderPlot({
+    output$outputs_totalNumberOfTests <- shiny::renderPlot({
         plotTotalNumberOfTests(fp, mod, likdat)
     })
 
-    output$outputs_numberOfPositiveTests <- renderPlot({
+    output$outputs_numberOfPositiveTests <- shiny::renderPlot({
         plotNumberOfPositiveTests(fp, mod, likdat)
     })
 
-    output$outputs_percentageNegativeOfTested <- renderPlot({
+    output$outputs_percentageNegativeOfTested <- shiny::renderPlot({
         plotPercentageNegativeOfTested(surveyAsDataTable, out_evertest)
     })
 
-    output$outputs_percentagePLHIVOfTested <- renderPlot({
+    output$outputs_percentagePLHIVOfTested <- shiny::renderPlot({
         plotPercentagePLHIVOfTested(surveyAsDataTable, out_evertest)
     })
 
-    output$outputs_percentageTested <- renderPlot({
+    output$outputs_percentageTested <- shiny::renderPlot({
         plotPercentageTested(surveyAsDataTable, out_evertest)
     })
 
-    output$outputs_firstAndSecond90 <- renderPlot({
+    output$outputs_firstAndSecond90 <- shiny::renderPlot({
         plotFirstAndSecond90(fp, mod, out_evertest)
     })
 }

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -1,5 +1,3 @@
-library(purrr)
-
 modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
     state <- shiny::reactiveValues()
     state$state <- "not_run"

--- a/src/server/plot_inputs.R
+++ b/src/server/plot_inputs.R
@@ -1,7 +1,5 @@
-library(shiny)
-
 plotInputs <- function(output, surveyAndProgramData, spectrumFilesState) {
-    output$inputReview <- renderPlot({
-        plot_inputdata(surveyAndProgramData$program(), spectrumFilesState$combinedData())
+    output$inputReview <- shiny::renderPlot({
+        first90::plot_inputdata(surveyAndProgramData$program(), spectrumFilesState$combinedData())
     })
 }

--- a/src/server/save_and_load.R
+++ b/src/server/save_and_load.R
@@ -1,7 +1,3 @@
-library(shiny)
-library(glue)
-library(purrr)
-
 doAndRememberPath <- function(paths, path, func) {
     paths <- c(paths, path)
     func(path)
@@ -9,7 +5,7 @@ doAndRememberPath <- function(paths, path, func) {
 }
 
 removeExtension <- function(path, extension) {
-    regexp <- glue(".{extension}$")
+    regexp <- glue::glue(".{extension}$")
     gsub(regexp, "", path)
 }
 
@@ -25,8 +21,8 @@ writeFilesForDigest <- function(workingSet, spectrumFilesState, surveyAndProgram
         file.writeText(path, workingSet$notes)
     })
     dir.create("spectrum_data")
-    paths <- reduce(spectrumFilesState$dataSets, .init = paths, function(paths, dataSet) {
-        path <- file.path("spectrum_data", glue("{dataSet$name}.rds"))
+    paths <- purrr::reduce(spectrumFilesState$dataSets, .init = paths, function(paths, dataSet) {
+        path <- file.path("spectrum_data", glue::glue("{dataSet$name}.rds"))
         doAndRememberPath(paths, path, function(path) {
             saveRDS(dataSet$data, file = path)
         })
@@ -53,8 +49,8 @@ withDir <- function(dir, expr) {
 }
 
 handleSave <- function(input, output, workingSet, spectrumFilesState, surveyAndProgramData) {
-    output$digestDownload <- downloadHandler(
-        filename = function() { glue("{workingSet$name}.zip.shiny90") },
+    output$digestDownload <- shiny::downloadHandler(
+        filename = function() { glue::glue("{workingSet$name}.zip.shiny90") },
         contentType = "application/zip",
         content = function(file) {
             readmeTemplate <- file.readText("template_for_digest_readme.md")
@@ -70,15 +66,15 @@ handleSave <- function(input, output, workingSet, spectrumFilesState, surveyAndP
 }
 
 handleLoad <- function(input, workingSet, surveyAndProgramData, spectrumFilesState) {
-    state <- reactiveValues()
+    state <- shiny::reactiveValues()
     state$uploadRequested <- FALSE
 
-    observeEvent(input$requestDigestUpload, { state$uploadRequested <- TRUE })
-    observeEvent(input$welcomeRequestDigestUpload, { state$uploadRequested <- TRUE })
-    observeEvent(input$cancelDigestUpload, {
+    shiny::observeEvent(input$requestDigestUpload, { state$uploadRequested <- TRUE })
+    shiny::observeEvent(input$welcomeRequestDigestUpload, { state$uploadRequested <- TRUE })
+    shiny::observeEvent(input$cancelDigestUpload, {
         state$uploadRequested <- FALSE
     })
-    observeEvent(input$digestUpload, {
+    shiny::observeEvent(input$digestUpload, {
         inFile <- input$digestUpload
         if (!is.null(inFile)) {
             state$uploadRequested <- FALSE
@@ -89,7 +85,7 @@ handleLoad <- function(input, workingSet, surveyAndProgramData, spectrumFilesSta
                 workingSet$notes <- file.readText("notes.txt")
                 surveyAndProgramData$survey <- read.csv("survey.csv")
                 surveyAndProgramData$program_wide <- read.csv("program.csv")
-                spectrumFilesState$dataSets <- map(list.files("spectrum_data"), function(path) {
+                spectrumFilesState$dataSets <- purrr::map(list.files("spectrum_data"), function(path) {
                     list(
                         name = removeExtension(path, "rds"),
                         data = readRDS(file.path("spectrum_data", path))

--- a/src/server/spectrum_files.R
+++ b/src/server/spectrum_files.R
@@ -1,4 +1,4 @@
-library(first90)
+library(eppasm)
 
 spectrumFiles <- function(input, output, state) {
     state$country <- NULL
@@ -68,7 +68,7 @@ addDynamicObserver <- function(input, observerList, eventId, handler) {
 renderSpectrumPlots <- function(output, combinedData) {
     output$spectrum_plots <- shiny::renderPlot({
         if (!is.null(combinedData())) {
-            plot_pnjz(combinedData())
+            first90::plot_pnjz(combinedData())
         }
     })
 }

--- a/src/server/survey_and_program_data.R
+++ b/src/server/survey_and_program_data.R
@@ -1,15 +1,12 @@
-library(tidyr)
-library(shiny)
-library(data.table)
-library(rhandsontable)
 library(first90)
+library(data.table)
 
 getProgramDataInWideFormat <- function(country) {
     data(prgm_dat)
     long <- prgm_dat[prgm_dat$country == country, ]
     long$country <- NULL
     long$notes <- NULL
-    wide <- spread(long, key = "type", value = "number")
+    wide <- tidyr::spread(long, key = "type", value = "number")
     wide[c("year", "NbTested", "NbTestPos", "NbANCTested", "NBTestedANCPos")]
 }
 
@@ -17,12 +14,12 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
     data(survey_hts)
     data(prgm_dat)
 
-    observeEvent(spectrumFilesState$country, {
+    shiny::observeEvent(spectrumFilesState$country, {
         state$survey <- as.data.frame(survey_hts[country == spectrumFilesState$country & outcome == "evertest"])
         state$program_wide <- getProgramDataInWideFormat(spectrumFilesState$country)
     })
-    state$program <- reactive({
-        gather(state$program_wide,
+    state$program <- shiny::reactive({
+        tidyr::gather(state$program_wide,
             key = "type", value = "number",
             "NbTested", "NbTestPos", "NbANCTested", "NBTestedANCPos"
         )
@@ -33,26 +30,26 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
             td.style.textAlign = 'right';
         }"
 
-    output$hot_survey <- renderRHandsontable({
-        rhandsontable(state$survey, stretchH = "all") %>%
-        hot_col("outcome", allowInvalid = TRUE) %>%
-        hot_col("agegr", allowInvalid = TRUE)  %>%
-        hot_col("est", renderer = number_renderer) %>%
-        hot_col("se", renderer = number_renderer) %>%
-        hot_col("ci_l", renderer = number_renderer) %>%
-        hot_col("ci_u", renderer = number_renderer) %>%
-        hot_col("year", format = "0")
+    output$hot_survey <- rhandsontable::renderRHandsontable({
+        rhandsontable::rhandsontable(state$survey, stretchH = "all") %>%
+            rhandsontable::hot_col("outcome", allowInvalid = TRUE) %>%
+            rhandsontable::hot_col("agegr", allowInvalid = TRUE)  %>%
+            rhandsontable::hot_col("est", renderer = number_renderer) %>%
+            rhandsontable::hot_col("se", renderer = number_renderer) %>%
+            rhandsontable::hot_col("ci_l", renderer = number_renderer) %>%
+            rhandsontable::hot_col("ci_u", renderer = number_renderer) %>%
+            rhandsontable::hot_col("year", format = "0")
     })
 
-    output$hot_program <- renderRHandsontable({
-        rhandsontable(state$program_wide, stretchH = "all") %>%
-            hot_col("NbTested", renderer = number_renderer) %>%
-            hot_col("NbTestPos", renderer = number_renderer) %>%
-            hot_col("NbANCTested", renderer = number_renderer) %>%
-            hot_col("NBTestedANCPos", renderer = number_renderer)
+    output$hot_program <- rhandsontable::renderRHandsontable({
+        rhandsontable::rhandsontable(state$program_wide, stretchH = "all") %>%
+            rhandsontable::hot_col("NbTested", renderer = number_renderer) %>%
+            rhandsontable::hot_col("NbTestPos", renderer = number_renderer) %>%
+            rhandsontable::hot_col("NbANCTested", renderer = number_renderer) %>%
+            rhandsontable::hot_col("NBTestedANCPos", renderer = number_renderer)
     })
 
-    observeEvent(input$surveyData, {
+    shiny::observeEvent(input$surveyData, {
         inFile <- input$surveyData
 
         if (is.null(inFile)){
@@ -62,7 +59,7 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
         state$survey <<- read.csv(inFile$datapath)
     })
 
-    observeEvent(input$programData, {
+    shiny::observeEvent(input$programData, {
         inFile <- input$programData
 
         if (is.null(inFile)){
@@ -72,15 +69,15 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
         state$program <<- read.csv(inFile$datapath)
     })
 
-    observe({
+    shiny::observe({
         if(!is.null(input$hot_survey)){
-            state$survey <<- hot_to_r(input$hot_survey)
+            state$survey <<- rhandsontable::hot_to_r(input$hot_survey)
         }
     })
 
-    observe({
+    shiny::observe({
         if(!is.null(input$hot_program)){
-            state$program_wide <- hot_to_r(input$hot_program)
+            state$program_wide <- rhandsontable::hot_to_r(input$hot_program)
         }
     })
 

--- a/src/server/survey_and_program_data.R
+++ b/src/server/survey_and_program_data.R
@@ -1,8 +1,6 @@
-library(first90)
 library(magrittr)
 
 getProgramDataInWideFormat <- function(country) {
-    data(prgm_dat)
     long <- prgm_dat[prgm_dat$country == country, ]
     long$country <- NULL
     long$notes <- NULL
@@ -11,8 +9,8 @@ getProgramDataInWideFormat <- function(country) {
 }
 
 surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
-    data(survey_hts)
-    data(prgm_dat)
+    data("survey_hts", package="first90")
+    data("prgm_dat", package="first90")
 
     shiny::observeEvent(spectrumFilesState$country, {
         state$survey <- as.data.frame(survey_hts)

--- a/src/server/survey_and_program_data.R
+++ b/src/server/survey_and_program_data.R
@@ -1,5 +1,5 @@
 library(first90)
-library(data.table)
+library(magrittr)
 
 getProgramDataInWideFormat <- function(country) {
     data(prgm_dat)
@@ -15,7 +15,8 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
     data(prgm_dat)
 
     shiny::observeEvent(spectrumFilesState$country, {
-        state$survey <- as.data.frame(survey_hts[country == spectrumFilesState$country & outcome == "evertest"])
+        state$survey <- as.data.frame(survey_hts)
+        state$survey <- state$survey[state$survey$country == spectrumFilesState$country & state$survey$outcome == "evertest", ]
         state$program_wide <- getProgramDataInWideFormat(spectrumFilesState$country)
     })
     state$program <- shiny::reactive({

--- a/src/server/working_set.R
+++ b/src/server/working_set.R
@@ -1,14 +1,12 @@
-library(shiny)
-
 workingSetLogic <- function(input, output, session, workingSet) {
     # Outputs
-    output$workingSet_selected <- reactive({ !is.null(workingSet$name) })
-    output$workingSet_name <- reactive({ workingSet$name })
-    output$workingSet_notes <- reactive({ workingSet$notes })
-    output$workingSet_creation_error <- reactive({ workingSet$creation_error })
+    output$workingSet_selected <- shiny::reactive({ !is.null(workingSet$name) })
+    output$workingSet_name <- shiny::reactive({ workingSet$name })
+    output$workingSet_notes <- shiny::reactive({ workingSet$notes })
+    output$workingSet_creation_error <- shiny::reactive({ workingSet$creation_error })
 
     # Creating a new one
-    observeEvent(input$startNewWorkingSet, {
+    shiny::observeEvent(input$startNewWorkingSet, {
         if (input$workingSetName != "") {
             workingSet$name <- input$workingSetName
             workingSet$notes <- ""
@@ -17,18 +15,18 @@ workingSetLogic <- function(input, output, session, workingSet) {
             workingSet$creation_error <- "A name is required"
         }
     })
-    outputOptions(output, "workingSet_creation_error", suspendWhenHidden = FALSE)
-    outputOptions(output, "workingSet_selected", suspendWhenHidden = FALSE)
+    shiny::outputOptions(output, "workingSet_creation_error", suspendWhenHidden = FALSE)
+    shiny::outputOptions(output, "workingSet_selected", suspendWhenHidden = FALSE)
 
     # Editing
-    observeEvent(input$editWorkingSet, {
+    shiny::observeEvent(input$editWorkingSet, {
         workingSet$editing = TRUE
-        updateTextInput(session, "editWorkingSet_name", value = workingSet$name)
-        updateTextInput(session, "editWorkingSet_notes", value = workingSet$notes)
+        shiny::updateTextInput(session, "editWorkingSet_name", value = workingSet$name)
+        shiny::updateTextInput(session, "editWorkingSet_notes", value = workingSet$notes)
     })
-    observeEvent(input$editWorkingSet_cancel_cross, { workingSet$editing <- FALSE })
-    observeEvent(input$editWorkingSet_cancel_button, { workingSet$editing <- FALSE })
-    observeEvent(input$editWorkingSet_update, {
+    shiny::observeEvent(input$editWorkingSet_cancel_cross, { workingSet$editing <- FALSE })
+    shiny::observeEvent(input$editWorkingSet_cancel_button, { workingSet$editing <- FALSE })
+    shiny::observeEvent(input$editWorkingSet_update, {
         workingSet$editing <- FALSE
         workingSet$name <- input$editWorkingSet_name
         workingSet$notes <- input$editWorkingSet_notes

--- a/src/ui.R
+++ b/src/ui.R
@@ -1,42 +1,39 @@
-library(shiny)
-library(shinyjs)
-
 disableUIOnBusy <- function() {
     div("", class = "modal busy-indicator",
         div("", class = "modal-dialog",
             div("", class = "modal-content",
                 div("", class = "modal-body",
                     p("Please wait..."),
-                    img(src = "images/ajax-loader.gif")
+                    shiny::img(src = "images/ajax-loader.gif")
                 )
             )
         ),
-        includeScript("js/disableUIOnBusy.js")
+        shiny::includeScript("js/disableUIOnBusy.js")
     )
 }
 
 ui <- div(id = "shiny90",
-    includeCSS("css/style.css"),
-    includeCSS("css/bootstrap4.css"),
+    shiny::includeCSS("css/style.css"),
+    shiny::includeCSS("css/bootstrap4.css"),
 
-    useShinyjs(),
-    extendShinyjs(text = file.readText("js/nav.js"), functions = c("enableTab", "disableTab")),
+    shinyjs::useShinyjs(),
+    shinyjs::extendShinyjs(text = file.readText("js/nav.js"), functions = c("enableTab", "disableTab")),
 
-    includeScript("js/enableEnterButton.js"),
+    shiny::includeScript("js/enableEnterButton.js"),
 
-    conditionalPanel(
+    shiny::conditionalPanel(
         condition = "!output.workingSet_selected",
         welcomeView()
     ),
-    conditionalPanel(
+    shiny::conditionalPanel(
         condition = "output.workingSet_selected",
         mainView()
     ),
-    conditionalPanel(
+    shiny::conditionalPanel(
         condition = "output.modal == 'loadDigest'",
         loadDigestModal()
     ),
-    conditionalPanel(
+    shiny::conditionalPanel(
         condition = "output.modal == 'editWorkingSet'",
         editWorkingSetModal()
     ),

--- a/src/ui/digest_buttons.R
+++ b/src/ui/digest_buttons.R
@@ -1,5 +1,3 @@
-library(shiny)
-
 digestButtons <- function() {
     div("", style = "width: 64px; display: inline-block",
         a(id='digestDownload',
@@ -7,14 +5,14 @@ digestButtons <- function() {
             href = "",
             target = "_blank",
             download = NA,
-            img(id = "digest-download-img", src = "images/cloud-download-red.svg", width = 32, height = 32),
-            tags$br(),
-            tags$label(`for`="digest-download-img", "Save")
+            shiny::img(id = "digest-download-img", src = "images/cloud-download-red.svg", width = 32, height = 32),
+            shiny::tags$br(),
+            shiny::tags$label(`for`="digest-download-img", "Save")
         ),
         actionButtonWithCustomClass("requestDigestUpload", label = "", cssClasses = "digest-button btn-sq btn-sq-sm btn-red text-center",
-            img(id = "digest-upload-img", src = "images/cloud-upload-red.svg", width = 32, height = 32),
-            tags$br(),
-            tags$label(`for`="digest-upload-img", "Load")
+            shiny::img(id = "digest-upload-img", src = "images/cloud-upload-red.svg", width = 32, height = 32),
+            shiny::tags$br(),
+            shiny::tags$label(`for`="digest-upload-img", "Load")
         )
     )
 }

--- a/src/ui/input_panels.R
+++ b/src/ui/input_panels.R
@@ -1,17 +1,13 @@
-library(shiny)
-library(rhandsontable)
-library(shinycssloaders)
-
 panelSurvey <- function() {
     div("",
         div("The following is survey data sourced from DHS and PHIA. You can edit the data below in the browser, or copy and
              paste to Excel and edit the data there. You can also replace the data entirely be uploading a new CSV file
              below", class = "mb-3"),
-        h3("Edit data in place"),
+        shiny::h3("Edit data in place"),
         div("Hint: Select rows and use ctrl-c to copy to clipboard. Use ctrl-v to paste rows from excel.", class = "text-muted"),
-        rHandsontableOutput("hot_survey"),
-        h3("Or upload new data"),
-        fileInput("surveyData", "Choose CSV File", accept = c("text/csv","text/comma-separated-values,text/plain",".csv"))
+        rhandsontable::rHandsontableOutput("hot_survey"),
+        shiny::h3("Or upload new data"),
+        shiny::fileInput("surveyData", "Choose CSV File", accept = c("text/csv","text/comma-separated-values,text/plain",".csv"))
     )
 }
 
@@ -21,11 +17,11 @@ panelProgram <- function() {
              You can edit the data below in the browser, or copy and paste to Excel and edit the data there.
              You can also replace the data entirely be uploading a new CSV file below",
             class = "mb-3"),
-        h3("Upload new data"),
-        fileInput("programData", "Choose CSV File", accept = c("text/csv","text/comma-separated-values,text/plain",".csv")),
-        h3("Or edit data in place"),
+        shiny::h3("Upload new data"),
+        shiny::fileInput("programData", "Choose CSV File", accept = c("text/csv","text/comma-separated-values,text/plain",".csv")),
+        shiny::h3("Or edit data in place"),
         div("Hint: Select rows and use ctrl-c to copy to clipboard. Use ctrl-v to paste rows from excel.", class = "text-muted"),
-        rHandsontableOutput("hot_program")
+        rhandsontable::rHandsontableOutput("hot_program")
     )
     # TODO: Should always have (blank rows if no data) years from 2005 - current year
 }
@@ -37,11 +33,11 @@ panelReviewInput <- function() {
             class = "mb-3"
         ),
         div("",
-            span("Once you have reviewed your input data, you may want to "),
-            tags$a(href = "#", "download a digest file"),
-            span("containing your input data and results. You can re-upload this file later to view your results again and change your input data.")
+            shiny::span("Once you have reviewed your input data, you may want to "),
+            shiny::tags$a(href = "#", "download a digest file"),
+            shiny::span("containing your input data and results. You can re-upload this file later to view your results again and change your input data.")
         ),
-        withSpinner(plotOutput(outputId = "inputReview", height = "800px"))
+        shinycssloaders::withSpinner(shiny::plotOutput(outputId = "inputReview", height = "800px"))
     )
     # TODO: More plots when Jeff knows what's needed
 }

--- a/src/ui/main_view.R
+++ b/src/ui/main_view.R
@@ -1,9 +1,9 @@
 mainView <- function() {
     div("",
         div("", class = "header",
-            fluidPage(
+            shiny::fluidPage(
                 div("", class = "pull-right text-right",
-                    tags$small("",
+                    shiny::tags$small("",
                         a("About this program and the underlying model", href = "#")
                     )
                 ),
@@ -13,7 +13,7 @@ mainView <- function() {
                 )
             )
         ),
-        fluidPage(class = "main-content",
+        shiny::fluidPage(class = "main-content",
             navigationPanel()
         )
     )

--- a/src/ui/modals.R
+++ b/src/ui/modals.R
@@ -1,10 +1,8 @@
-library(shiny)
-
 loadDigestModal <- function() {
     modal(
         title = "Load digest file",
         cancelId = "cancelDigestUpload",
-        fileInput("digestUpload", "Choose a Shiny 90 digest file", accept = ".zip.shiny90")
+        shiny::fileInput("digestUpload", "Choose a Shiny 90 digest file", accept = ".zip.shiny90")
     )
 }
 
@@ -12,10 +10,10 @@ editWorkingSetModal <- function() {
     modal(
         title = "Edit working set",
         cancelId = "editWorkingSet_cancel_cross",
-        tags$form("",
+        shiny::tags$form("",
             inputBox("editWorkingSet_name", "Name", type = "text", value = ""),
             inputBox("editWorkingSet_notes", "Notes", multiline = TRUE),
-            fluidRow(
+            shiny::fluidRow(
                 div("", class = "col-md-6",
                     actionButtonWithCustomClass("editWorkingSet_cancel_button", "Cancel", cssClasses = "btn-red")
                 ),

--- a/src/ui/model_outputs_panel.R
+++ b/src/ui/model_outputs_panel.R
@@ -1,11 +1,9 @@
-library(shiny)
-
 panelModelOutputs <- function() {
     div("",
         div("",
-            span("Now that the model has been run, you can "),
-            tags$a(href = "#", "download a digest file"),
-            span("containing your input data and results. You can re-upload this file later to view your results again and change your input data.")
+            shiny::span("Now that the model has been run, you can "),
+            shiny::tags$a(href = "#", "download a digest file"),
+            shiny::span("containing your input data and results. You can re-upload this file later to view your results again and change your input data.")
         ),
         div("", class = "row",
             div("", class = "col-md-6 col-sm-12", shinycssloaders::withSpinner(plotOutput(outputId = "outputs_totalNumberOfTests"))),
@@ -19,14 +17,14 @@ panelModelOutputs <- function() {
             div("", class = "col-md-6 col-sm-12", shinycssloaders::withSpinner(plotOutput(outputId = "outputs_percentageTested"))),
             div("", class = "col-md-6 col-sm-12", shinycssloaders::withSpinner(plotOutput(outputId = "outputs_firstAndSecond90")))
         ),
-        h3("Tabular data"),
+        shiny::h3("Tabular data"),
         # TODO
         # By year (2000 to current):
         # - Proportion ever tested by status
         # - Proportion aware
         # - ART coverage
         # Download full long format data set (stratified by age and sex)
-        img(src = "images/mock-sheet.png")
+        shiny::img(src = "images/mock-sheet.png")
 
         # TODO
         # We want these 6 plots for the full output age range without original data points

--- a/src/ui/model_outputs_panel.R
+++ b/src/ui/model_outputs_panel.R
@@ -1,5 +1,4 @@
 library(shiny)
-library(shinycssloaders)
 
 panelModelOutputs <- function() {
     div("",
@@ -9,16 +8,16 @@ panelModelOutputs <- function() {
             span("containing your input data and results. You can re-upload this file later to view your results again and change your input data.")
         ),
         div("", class = "row",
-            div("", class = "col-md-6 col-sm-12", withSpinner(plotOutput(outputId = "outputs_totalNumberOfTests"))),
-            div("", class = "col-md-6 col-sm-12", withSpinner(plotOutput(outputId = "outputs_numberOfPositiveTests")))
+            div("", class = "col-md-6 col-sm-12", shinycssloaders::withSpinner(plotOutput(outputId = "outputs_totalNumberOfTests"))),
+            div("", class = "col-md-6 col-sm-12", shinycssloaders::withSpinner(plotOutput(outputId = "outputs_numberOfPositiveTests")))
         ),
         div("", class = "row",
-            div("", class = "col-md-6 col-sm-12", withSpinner(plotOutput(outputId = "outputs_percentageNegativeOfTested"))),
-            div("", class = "col-md-6 col-sm-12", withSpinner(plotOutput(outputId = "outputs_percentagePLHIVOfTested")))
+            div("", class = "col-md-6 col-sm-12", shinycssloaders::withSpinner(plotOutput(outputId = "outputs_percentageNegativeOfTested"))),
+            div("", class = "col-md-6 col-sm-12", shinycssloaders::withSpinner(plotOutput(outputId = "outputs_percentagePLHIVOfTested")))
         ),
         div("", class = "row",
-            div("", class = "col-md-6 col-sm-12", withSpinner(plotOutput(outputId = "outputs_percentageTested"))),
-            div("", class = "col-md-6 col-sm-12", withSpinner(plotOutput(outputId = "outputs_firstAndSecond90")))
+            div("", class = "col-md-6 col-sm-12", shinycssloaders::withSpinner(plotOutput(outputId = "outputs_percentageTested"))),
+            div("", class = "col-md-6 col-sm-12", shinycssloaders::withSpinner(plotOutput(outputId = "outputs_firstAndSecond90")))
         ),
         h3("Tabular data"),
         # TODO

--- a/src/ui/model_run_panel.R
+++ b/src/ui/model_run_panel.R
@@ -1,7 +1,7 @@
 panelModelRun <- function() {
     div("",
-        h3("Enter model fitting parameters"),
-        fluidRow(
+        shiny::h3("Enter model fitting parameters"),
+        shiny::fluidRow(
             div("", class = "col-xs-12 col-sm-6",
                 inputBox("parameter2", "A", "Explantation for parameter A", value = "500"),
                 inputBox("parameter1", "X", "Explantation for parameter B", value = "5")
@@ -10,10 +10,10 @@ panelModelRun <- function() {
         ),
         actionButtonWithCustomClass("runModel", "Run model", cssClasses = "btn-red btn-lg btn-success"),
         div("This make take several minutes. Please do not close your browser.", class = "mt-3"),
-        conditionalPanel(
+        shiny::conditionalPanel(
             condition = "output.modelRunState == 'finished'",
             div("", class = "mt-3",
-                h2("Model run complete"),
+                shiny::h2("Model run complete"),
                 div("Click 'View model outputs' in the sidebar to see the outputs")
                 # We want the 6 plots currently on the output page, constrained to the age range
                 # present in the input data and with the original data points plotted

--- a/src/ui/navigation.R
+++ b/src/ui/navigation.R
@@ -1,8 +1,5 @@
-library(shiny)
-library(shinyjs)
-
 navigationPanel <- function() {
-    navlistPanel(well = FALSE, widths = c(2, 10),
+    shiny::navlistPanel(well = FALSE, widths = c(2, 10),
         panelWithTitle("Upload spectrum file(s)", panelSpectrum()),
         panelWithTitle("Upload survey data", panelSurvey()),
         panelWithTitle("Upload programmatic data", panelProgram()),
@@ -13,8 +10,8 @@ navigationPanel <- function() {
 }
 
 panelWithTitle <- function(title, content) {
-    tabPanel(title, div("",
-        h1(title),
+    shiny::tabPanel(title, div("",
+        shiny::h1(title),
         content
     ))
 }
@@ -31,12 +28,12 @@ enableNavLinks <- function(input, output, spectrumFilesState, modelRunState) {
 }
 
 enableTabWhen <- function(tabTitle, condition) {
-    js$disableTab(tabTitle)
-    observe({
+    shinyjs::js$disableTab(tabTitle)
+    shiny::observe({
         if (condition()) {
-            js$enableTab(tabTitle)
+            shinyjs::js$enableTab(tabTitle)
         } else {
-            js$disableTab(tabTitle)
+            shinyjs::js$disableTab(tabTitle)
         }
     })
 }

--- a/src/ui/shapes.R
+++ b/src/ui/shapes.R
@@ -1,7 +1,5 @@
-library(shiny)
-
 edit_link <- function(id) {
     a("Edit", href = "#", title = "Edit", id = id, class = "action-button shiny-bound-input",
-        HTML('<svg xmlns="http://www.w3.org/2000/svg" fill="#e31837" width="14" height="16" viewBox="0 0 14 16"><path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"/></svg>')
+        shiny::HTML('<svg xmlns="http://www.w3.org/2000/svg" fill="#e31837" width="14" height="16" viewBox="0 0 14 16"><path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"/></svg>')
     )
 }

--- a/src/ui/spectrum_files_panel.R
+++ b/src/ui/spectrum_files_panel.R
@@ -1,32 +1,29 @@
-library(shiny)
-library(shinycssloaders)
-
 panelSpectrum <- function() {
     div("",
         div("Please upload either one national PJNZ file or multiple files, one per subnational region.",
             class = "mb-5"),
         div("", class = "mt-3 mb-5",
-            fileInput("spectrumFile", "Choose PJNZ File", accept = c(".pjnz"))
+            shiny::fileInput("spectrumFile", "Choose PJNZ File", accept = c(".pjnz"))
         ),
-        conditionalPanel(condition = "output.anySpectrumDataSets",
+        shiny::conditionalPanel(condition = "output.anySpectrumDataSets",
             div("", class = "mb-5",
-                h3("Uploaded PJNZ files", class = "mt-5"),
-                tags$ul("", class = "list-group",
-                    uiOutput("spectrumFileList")
+                shiny::h3("Uploaded PJNZ files", class = "mt-5"),
+                shiny::tags$ul("", class = "list-group",
+                    shiny::uiOutput("spectrumFileList")
                 )
             ),
 
             div("",
-                h3("", class = "mt-5",
-                    textOutput("spectrumFilesCountry", inline = TRUE),
-                    span("PJNZ data (combined)")
+                shiny::h3("", class = "mt-5",
+                    shiny::textOutput("spectrumFilesCountry", inline = TRUE),
+                    shiny::span("PJNZ data (combined)")
                 ),
 
-                tabsetPanel(
-                    tabPanel("Figures", withSpinner(plotOutput(outputId = "spectrum_plots", height = "800px"))),
-                    tabPanel("Data",
+                shiny::tabsetPanel(
+                    shiny::tabPanel("Figures", shinycssloaders::withSpinner(shiny::plotOutput(outputId = "spectrum_plots", height = "800px"))),
+                    shiny::tabPanel("Data",
                         div("", class = "mt-3",
-                            img(src = "images/mock-sheet.png")
+                            shiny::img(src = "images/mock-sheet.png")
                         )
                     )
                 )

--- a/src/ui/ui_helpers.R
+++ b/src/ui/ui_helpers.R
@@ -1,26 +1,24 @@
-library(shiny)
-
 inputBox <- function(id, label, explanation = "", type = "number", value = 0, multiline = FALSE) {
     classes <- "form-control shiny-bound-input"
     if (multiline) {
-        control <- tags$textarea(id = id, class = classes, rows = 10)
+        control <- shiny::tags$textarea(id = id, class = classes, rows = 10)
     } else {
-        control <- tags$input(id = id, type = type, value = value, class = classes)
+        control <- shiny::tags$input(id = id, type = type, value = value, class = classes)
     }
 
     div("", class = "form-group",
-        tags$label(`for`=id,
-            tags$strong(label),
-            HTML("&nbsp;&nbsp;"),
-            span(explanation, style = "font-weight: normal")
+        shiny::tags$label(`for`=id,
+            shiny::tags$strong(label),
+            shiny::HTML("&nbsp;&nbsp;"),
+            shiny::span(explanation, style = "font-weight: normal")
         ),
         control
     )
 }
 
 actionButtonWithCustomClass <- function (inputId, label, ..., cssClasses = NULL, type = "button") {
-    value <- restoreInput(id = inputId, default = NULL)
-    tags$button(id = inputId, type = type,
+    value <- shiny::restoreInput(id = inputId, default = NULL)
+    shiny::tags$button(id = inputId, type = type,
         class = paste("btn btn-default action-button ", cssClasses), `data-val` = value,
         list(label), ...)
 }

--- a/src/ui/welcome_view.R
+++ b/src/ui/welcome_view.R
@@ -1,48 +1,46 @@
-library(shiny)
-
 welcomeView <- function() {
-    fluidPage(
+    shiny::fluidPage(
         div("", class = "welcome",
-            fluidRow(class = "row align-items-center",
+            shiny::fluidRow(class = "row align-items-center",
                 div("", class = "col-md-8 col-sm-12 col-md-offset-2",
-                    h1("Shiny 90", class = "title"),
+                shiny::h1("Shiny 90", class = "title"),
                     p("",
-                        HTML('UN Aids have an ambitious treatment target to help end the AIDS epidemic,
+                        shiny::HTML('UN Aids have an ambitious treatment target to help end the AIDS epidemic,
                              <a href="http://www.unaids.org/en/resources/documents/2017/90-90-90">the three 90s</a>:'),
-                        tags$ul("",
-                            tags$li("By 2020, 90% of all people living with HIV will know their HIV status."),
-                            tags$li("By 2020, 90% of all people with diagnosed HIV infection will receive sustained antiretroviral therapy."),
-                            tags$li("By 2020, 90% of all people receiving antiretroviral therapy will have viral suppression.")
+                        shiny::tags$ul("",
+                            shiny::tags$li("By 2020, 90% of all people living with HIV will know their HIV status."),
+                            shiny::tags$li("By 2020, 90% of all people with diagnosed HIV infection will receive sustained antiretroviral therapy."),
+                            shiny::tags$li("By 2020, 90% of all people receiving antiretroviral therapy will have viral suppression.")
                         )
                     ),
                     p("This tool models the 1st 90: what percentage of the popultation living with HIV (plHIV) have been diagnosed?"),
                     p("",
-                        span("You will need input data from the UN AIDS"),
-                        HTML('<a href="http://www.unaids.org/en/dataanalysis/datatools/spectrum-epp">Spectrum tool</a>.'),
-                        span(
+                        shiny::span("You will need input data from the UN AIDS"),
+                        shiny::HTML('<a href="http://www.unaids.org/en/dataanalysis/datatools/spectrum-epp">Spectrum tool</a>.'),
+                        shiny::span(
                             "This will be combined with survey and programmatic data. You can provide your own
                             survey and programmatic data, but the app comes with default data."
                         )
                     ),
-                    fluidRow(class = "row align-items-center mt-3",
+                    shiny::fluidRow(class = "row align-items-center mt-3",
                         div("", class = "col-md-6 welcome-option", style = "border-right: 1px solid rgb(200, 200, 200)",
-                            h3("Open an existing Shiny 90 working set"),
+                            shiny::h3("Open an existing Shiny 90 working set"),
                             div("This will be a file you downloaded from this app previously"),
                             div("", class = "text-center pt-4",
                                 actionButtonWithCustomClass("welcomeRequestDigestUpload",
                                     label = "", cssClasses = "btn-sq btn-red text-center",
-                                    img(id = "digest-upload-img", src = "images/cloud-upload-red.svg", width = 64, height = 64),
-                                    tags$br(),
-                                    tags$label(`for`="digest-upload-img", "Load")
+                                    shiny::img(id = "digest-upload-img", src = "images/cloud-upload-red.svg", width = 64, height = 64),
+                                    shiny::tags$br(),
+                                    shiny::tags$label(`for`="digest-upload-img", "Load")
                                 )
                             )
                         ),
                         div("", class = "col-md-6 welcome-option form-group",
-                            h3("Start a new blank working set"),
+                            shiny::h3("Start a new blank working set"),
                             div("You will have the option to upload data in a moment", class = "mb-3"),
-                            tags$label("Name:"),
+                            shiny::tags$label("Name:"),
                             div("", class = "input-group",
-                                tags$input(id = "workingSetName",
+                                shiny::tags$input(id = "workingSetName",
                                     type = "text",
                                     name = "workingSetName",
                                     class = "shiny-bound-input input-lg form-control",
@@ -53,11 +51,11 @@ welcomeView <- function() {
                                     actionButtonWithCustomClass("startNewWorkingSet", "Go", cssClasses = "btn-lg btn btn-red")
                                 )
                             ),
-                            conditionalPanel(
+                            shiny::conditionalPanel(
                                 condition = "output.workingSet_creation_error",
                                 div("", class = "has-error",
                                     div("", class = "help-block error",
-                                        textOutput("workingSet_creation_error", inline = TRUE)
+                                        shiny::textOutput("workingSet_creation_error", inline = TRUE)
                                     )
                                 )
                             )

--- a/src/ui/working_set_section.R
+++ b/src/ui/working_set_section.R
@@ -1,19 +1,17 @@
-library(shiny)
-
 workingSetSection <- function() {
     div("", class = "working-set",
         div("",
-            tags$strong("Current working set:"),
-            span("",
-                textOutput("workingSet_name", inline = TRUE)
+            shiny::tags$strong("Current working set:"),
+            shiny::span("",
+                shiny::textOutput("workingSet_name", inline = TRUE)
             ),
             div("", class = "pull-right",
                 edit_link("editWorkingSet")
             )
         ),
         div("",
-            tags$strong("Working set notes:"),
-            textOutput("workingSet_notes", inline = TRUE)
+            shiny::tags$strong("Working set notes:"),
+            shiny::textOutput("workingSet_notes", inline = TRUE)
         ),
         # Fades out notes that are too long to fit in box
         div("", style = "position: absolute; bottom: 0; left: 0; right: 0; height: 50px;


### PR DESCRIPTION
We've been using `library(packagename)` to load packages everywhere, but really we shouldn't be.
http://r-pkgs.had.co.nz/namespace.html

This PR gets rid of those calls and uses explicit namespaces in function calls to load packages as they are needed
