### PR TITLE
 i100 - re-set model run when data changes

### DIFF
--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -32,21 +32,22 @@ modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
 
         }
 
+        state$state <- "finished"
     })
 
     output$modelRunState <- shiny::reactive({ state$state })
     shiny::outputOptions(output, "modelRunState", suspendWhenHidden = FALSE)
 
     shiny::observeEvent(surveyAndProgramData$survey, {
-        state$state <- ""
+        if (surveyAndProgramData$surveyTableChanged > 1){
+            state$state <- ""
+        }
     })
 
     shiny::observeEvent(surveyAndProgramData$program_wide, {
-        state$state <- ""
-    })
-
-    shiny::observeEvent(surveyAndProgramData$program, {
-        state$state <- ""
+        if (surveyAndProgramData$programTableChanged > 1){
+            state$state <- ""
+        }
     })
 
     shiny::observeEvent(spectrumFilesState$combinedData(), {

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -35,6 +35,9 @@ modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
     output$modelRunState <- shiny::reactive({ state$state })
     shiny::outputOptions(output, "modelRunState", suspendWhenHidden = FALSE)
 
+    # A change event will occur the first time the user navigates to the input data page
+    # but this first change event doesn't represent a change to the data.
+    # So we only reset the state on subsequent change events.
     shiny::observeEvent(surveyAndProgramData$survey, {
         if (surveyAndProgramData$surveyTableChanged > 1){
             state$state <- ""

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -35,6 +35,18 @@ modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
     output$modelRunState <- shiny::reactive({ state$state })
     shiny::outputOptions(output, "modelRunState", suspendWhenHidden = FALSE)
 
+    shiny::observeEvent(surveyAndProgramData$survey, {
+        state$state <- ""
+    })
+
+    shiny::observeEvent(surveyAndProgramData$program, {
+        state$state <- ""
+    })
+
+    shiny::observeEvent(spectrumFilesState$program, {
+        state$state <- ""
+    })
+
     state
 }
 

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -40,6 +40,10 @@ modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
         state$state <- ""
     })
 
+    shiny::observeEvent(surveyAndProgramData$program_wide, {
+        state$state <- ""
+    })
+
     shiny::observeEvent(surveyAndProgramData$program, {
         state$state <- ""
     })

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -13,7 +13,6 @@ modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
                 fitModel(surveyAsDataTable, surveyAndProgramData$program(), spectrumFilesState$combinedData())
             },
             error = function(e) {
-                str(e)
                 state$state <- "error"
             })
 
@@ -31,8 +30,6 @@ modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
             state$state <- "finished"
 
         }
-
-        state$state <- "finished"
     })
 
     output$modelRunState <- shiny::reactive({ state$state })

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -13,6 +13,7 @@ modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
                 fitModel(surveyAsDataTable, surveyAndProgramData$program(), spectrumFilesState$combinedData())
             },
             error = function(e) {
+                str(e)
                 state$state <- "error"
             })
 
@@ -43,7 +44,7 @@ modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
         state$state <- ""
     })
 
-    shiny::observeEvent(spectrumFilesState$combinedData, {
+    shiny::observeEvent(spectrumFilesState$combinedData(), {
         state$state <- ""
     })
     

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -43,10 +43,10 @@ modelRun <- function(input, output, spectrumFilesState, surveyAndProgramData) {
         state$state <- ""
     })
 
-    shiny::observeEvent(spectrumFilesState$program, {
+    shiny::observeEvent(spectrumFilesState$combinedData, {
         state$state <- ""
     })
-
+    
     state
 }
 

--- a/src/server/spectrum_files.R
+++ b/src/server/spectrum_files.R
@@ -6,8 +6,15 @@ spectrumFiles <- function(input, output, state) {
     state$anyDataSets <- shiny::reactive({ length(state$dataSets) > 0 })
     state$combinedData <-shiny::reactive({
         if (state$anyDataSets()) {
+
+            str("spectrum data changed")
             # TODO use all files, not just first one
             state$dataSets[[1]]$data
+        }
+        else {
+
+            str("spectrum data changed")
+            NULL
         }
     })
 

--- a/src/server/spectrum_files.R
+++ b/src/server/spectrum_files.R
@@ -6,14 +6,10 @@ spectrumFiles <- function(input, output, state) {
     state$anyDataSets <- shiny::reactive({ length(state$dataSets) > 0 })
     state$combinedData <-shiny::reactive({
         if (state$anyDataSets()) {
-
-            str("spectrum data changed")
             # TODO use all files, not just first one
             state$dataSets[[1]]$data
         }
         else {
-
-            str("spectrum data changed")
             NULL
         }
     })

--- a/src/server/survey_and_program_data.R
+++ b/src/server/survey_and_program_data.R
@@ -95,6 +95,8 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
         state$program_wide <<- read.csv(inFile$datapath)
     })
 
+    # We track change events so that we know when to reset the model run state.
+    # See comment in model_run.R
     state$surveyTableChanged <- 0
     state$programTableChanged <- 0
 

--- a/src/server/survey_and_program_data.R
+++ b/src/server/survey_and_program_data.R
@@ -93,24 +93,23 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
             return(NULL)
         }
 
-        state$program <<- read.csv(inFile$datapath)
+        state$program_wide <<- read.csv(inFile$datapath)
     })
 
-    shiny::observe({
+    state$surveyTableChanged <- 0
+    state$programTableChanged <- 0
+
+    shiny::observeEvent(input$hot_survey, {
         if(!is.null(input$hot_survey)){
-            newTable <- rhandsontable::hot_to_r(input$hot_survey)
-            #if (!identical(newTable, state$survey)){
-                state$survey <<- newTable
-            #}
+            state$survey <<- rhandsontable::hot_to_r(input$hot_survey)
+            state$surveyTableChanged <<- state$surveyTableChanged + 1
         }
     })
 
-    shiny::observe({
+    shiny::observeEvent(input$hot_program, {
         if(!is.null(input$hot_program)){
-            newTable <- rhandsontable::hot_to_r(input$hot_program)
-            if (!identical(newTable, state$program_wide)){
-                state$program_wide <<- newTable
-            }
+            state$program_wide <<- rhandsontable::hot_to_r(input$hot_program)
+            state$programTableChanged <<- state$programTableChanged + 1
         }
     })
 

--- a/src/server/survey_and_program_data.R
+++ b/src/server/survey_and_program_data.R
@@ -1,7 +1,7 @@
 library(magrittr)
 
-getProgramDataInWideFormat <- function(long) {
-
+getProgramDataInWideFormat <- function(country) {
+    long <- prgm_dat[prgm_dat$country == country, ]
     long$country <- NULL
     long$notes <- NULL
 
@@ -34,8 +34,7 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
         if (!is.null(spectrumFilesState$country)){
             state$survey <- as.data.frame(survey_hts)
             state$survey <- state$survey[state$survey$country == spectrumFilesState$country & state$survey$outcome == "evertest", ]
-            long <- prgm_dat[prgm_dat$country == spectrumFilesState$country, ]
-            state$program_wide <- getProgramDataInWideFormat(long)
+            state$program_wide <- getProgramDataInWideFormat(spectrumFilesState$country)
         }
     })
 

--- a/src/server/survey_and_program_data.R
+++ b/src/server/survey_and_program_data.R
@@ -1,7 +1,7 @@
 library(magrittr)
 
-getProgramDataInWideFormat <- function(country) {
-    long <- prgm_dat[prgm_dat$country == country, ]
+getProgramDataInWideFormat <- function(long) {
+
     long$country <- NULL
     long$notes <- NULL
 
@@ -34,7 +34,8 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
         if (!is.null(spectrumFilesState$country)){
             state$survey <- as.data.frame(survey_hts)
             state$survey <- state$survey[state$survey$country == spectrumFilesState$country & state$survey$outcome == "evertest", ]
-            state$program_wide <- getProgramDataInWideFormat(spectrumFilesState$country)
+            long <- prgm_dat[prgm_dat$country == spectrumFilesState$country, ]
+            state$program_wide <- getProgramDataInWideFormat(long)
         }
     })
 
@@ -98,9 +99,9 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
     shiny::observe({
         if(!is.null(input$hot_survey)){
             newTable <- rhandsontable::hot_to_r(input$hot_survey)
-            if (!identical(newTable, state$survey)){
+            #if (!identical(newTable, state$survey)){
                 state$survey <<- newTable
-            }
+            #}
         }
     })
 

--- a/src/server/survey_and_program_data.R
+++ b/src/server/survey_and_program_data.R
@@ -89,7 +89,7 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
         inFile <- input$programData
 
         if (is.null(inFile)){
-        return(NULL)
+            return(NULL)
         }
 
         state$program <<- read.csv(inFile$datapath)
@@ -97,13 +97,19 @@ surveyAndProgramData <- function(input, output, state, spectrumFilesState) {
 
     shiny::observe({
         if(!is.null(input$hot_survey)){
-            state$survey <<- rhandsontable::hot_to_r(input$hot_survey)
+            newTable <- rhandsontable::hot_to_r(input$hot_survey)
+            if (!identical(newTable, state$survey)){
+                state$survey <<- newTable
+            }
         }
     })
 
     shiny::observe({
         if(!is.null(input$hot_program)){
-            state$program_wide <- rhandsontable::hot_to_r(input$hot_program)
+            newTable <- rhandsontable::hot_to_r(input$hot_program)
+            if (!identical(newTable, state$program_wide)){
+                state$program_wide <<- newTable
+            }
         }
     })
 


### PR DESCRIPTION
Invalidate the model run when underlying data has changed (ie survey, program or spectrum data) - disable the model results tab so the user has to run it again to see new results.