### PR TITLE
remove outcome column internally

### DIFF
--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -23,6 +23,7 @@ modelRun <- function(input, output, state, spectrumFilesState, surveyAndProgramD
             dt$ci_u = dt$ci_u/100
             dt$est = dt$est/100
             dt$se = dt$se/100
+            dt$outcome = "evertest"
 
             dt
         }


### PR DESCRIPTION
There's no reason for users of the app to have this the survey data's "outcome" column - outcome is always "evertest". But we need to add it back to the survey data when we feed it into `first90` functions.