### PR TITLE
I154 - Re-style download digest links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Shiny tool for the first 90 HIV model (https://github.com/mrc-ide/first90)
 Run
 
 ```
-./bootstrap
+./scripts/bootstrap
 ```
 
 to install R dependencies. If your system doesn't suppport bash, then instead 
@@ -27,14 +27,14 @@ SHINY90_TEST_MODE=TRUE ./run.R
 
 For unit tests:
 ```
-./bootstrap-dev.R
-./unittest
+./scripts/bootstrap-dev.R
+./scripts/unittest
 ```
 
 For Selenium tests:
 ```
-sudo ./install_geckodriver.sh
-./test
+sudo ./scripts/install_geckodriver.sh
+./scripts/test
 ```
 
 They should also run at https://circleci.com/gh/mrc-ide/workflows/shiny90

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -95,6 +95,13 @@
     border-color: #e31837;
 }
 
+.btn.shiny-download-link.btn-red.btn-success,
+.btn.shiny-download-link.btn-red.btn-success:hover,
+.btn.shiny-download-link.btn-red.btn-success:active {
+    font-weight:normal;
+    color: white;
+}
+
 .main-content {
     height: calc(100vh - 60px);
 }

--- a/src/tests/testthat/testLoading.R
+++ b/src/tests/testthat/testLoading.R
@@ -41,8 +41,8 @@ testthat::test_that("can save digest from review tab", {
     # Save it from review tab
     editWorkingSetMetadata(wd, "from_review")
     switchTab(wd, "Review input data")
-    link = wd$findElement("css", inActivePane(".suggest-save a"))
-    expectTextEqual("download a digest file", link)
+    link = wd$findElement("css", inActivePane(".save-button a"))
+    expectTextEqual("Save your work", link)
 
     downloadFileFromLink(link, "Malawi.zip.shiny90")
 
@@ -63,9 +63,9 @@ testthat::test_that("can save digest from output tab", {
     runModel()
 
     editWorkingSetMetadata(wd, "from_outputs")
-    link = wd$findElement("css", inActivePane(".suggest-save a"))
+    link = wd$findElement("css", inActivePane(".save-button a"))
     waitForVisible(link)
-    expectTextEqual("download a digest file", link)
+    expectTextEqual("Download shiny90 outputs for Spectrum", link)
 
     downloadFileFromLink(link, "Malawi.zip.shiny90")
 

--- a/src/ui/input_panels.R
+++ b/src/ui/input_panels.R
@@ -72,12 +72,12 @@ panelReviewInput <- function() {
             class = "mb-3"
         ),
         shiny::div("", class="suggest-save mb-3",
-            shiny::span("Once you have reviewed your input data, you may want to save your work. This 
-                        downloads a file containing your input data and results. You can re-upload this 
-                        later to view your results again and change your input data.")
+            shiny::span("Please save your work. This downloads a file containing your input data and results. 
+                        If you get disconnected from the server, or if you want to return to the app later 
+                        and review your results, you can re-upload this file and resume where you left off.")
         ),
         shiny::div("", class="save-button",
-            shiny::downloadButton('digestDownload3', "Save your work")
+            downloadButtonWithCustomClass("digestDownload3", "Save your work")
         ),
         shiny::conditionalPanel(
             condition = "output.incompleteProgramData",

--- a/src/ui/input_panels.R
+++ b/src/ui/input_panels.R
@@ -71,10 +71,13 @@ panelReviewInput <- function() {
             Please review it, and go back and edit your data if anything doesn't look right.",
             class = "mb-3"
         ),
-        shiny::div("", class="suggest-save",
-            shiny::span("Once you have reviewed your input data, you may want to "),
-            shiny::tags$a(class = "shiny-download-link", href = "", "download a digest file", id = "digestDownload3", download = NA, target = "_blank"),
-            shiny::span("containing your input data and results. You can re-upload this file later to view your results again and change your input data.")
+        shiny::div("", class="suggest-save mb-3",
+            shiny::span("Once you have reviewed your input data, you may want to save your work. This 
+                        downloads a file containing your input data and results. You can re-upload this 
+                        later to view your results again and change your input data.")
+        ),
+        shiny::div("", class="save-button",
+            shiny::downloadButton('digestDownload3', "Save your work")
         ),
         shiny::conditionalPanel(
             condition = "output.incompleteProgramData",

--- a/src/ui/model_outputs_panel.R
+++ b/src/ui/model_outputs_panel.R
@@ -11,7 +11,7 @@ panelModelOutputs <- function() {
                                 also re-upload this file later to view your results again and change your input data.")
                 ),
                 shiny::div("", class="mb-5 save-button",
-                    shiny::downloadButton('digestDownload2', "Download shiny90 outputs for Spectrum")
+                    downloadButtonWithCustomClass("digestDownload2", "Download shiny90 outputs for Spectrum")
                 ),
                 shiny::tabsetPanel(
                     shiny::tabPanel("Figures",

--- a/src/ui/model_outputs_panel.R
+++ b/src/ui/model_outputs_panel.R
@@ -5,10 +5,13 @@ panelModelOutputs <- function() {
         shiny::conditionalPanel(
             condition = "output.modelRunState == 'converged'",
             shiny::div("", id="model-outputs",
-                shiny::div("", class="mb-5 suggest-save",
-                    shiny::span("Now that the model has been run, you can "),
-                    shiny::tags$a(href = "", class="shiny-download-link", id="digestDownload2", "download a digest file", target = "_blank", download = NA),
-                    shiny::span("containing your input data and results. You can re-upload this file later to view your results again and change your input data.")
+                shiny::div("", class="mb-3 suggest-save",
+                    shiny::span("Now that the model has been run, you can download the shiny90 outputs for importing 
+                                into Spectrum. This will download a file containing your input data and results. You can 
+                                also re-upload this file later to view your results again and change your input data.")
+                ),
+                shiny::div("", class="mb-5 save-button",
+                    shiny::downloadButton('digestDownload2', "Download shiny90 outputs for Spectrum")
                 ),
                 shiny::tabsetPanel(
                     shiny::tabPanel("Figures",

--- a/src/ui/ui_helpers.R
+++ b/src/ui/ui_helpers.R
@@ -23,6 +23,13 @@ actionButtonWithCustomClass <- function (inputId, label, ..., cssClasses = NULL,
         list(label), ...)
 }
 
+downloadButtonWithCustomClass <- function (inputId, label, ..., cssClasses = NULL, type = "button") {
+  value <- shiny::restoreInput(id = inputId, default = NULL)
+  shiny::tags$a(id = inputId, label, href = "",
+                class = paste("btn btn-default btn-red btn-lg btn-success shiny-download-link", cssClasses),
+                download = NA, target = "_blank", ...)
+}
+
 modal <- function(title, id, cancelId, ...) {
     shiny::div("", class = "modal", id = id,
         shiny::div("", class = "modal-dialog",


### PR DESCRIPTION
Updated download links on "review input data" and "run model" pages.

Would be good in particular if you can check if this is implemented in most appropriate way. Also updated tests to reflect updated css classes.