### PR TITLE
remove need for github pat now that first90 dependency is open source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
   - git clone https://$github_pat@github.com/mrc-ide/shiny90_sample_files sample_files
   - cd sample_files && git checkout $submodule_commit
   - cd ../
-  - echo $github_pat > github_token
   - export $(dbus-launch)
 install:
   - ./scripts/bootstrap

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -2,14 +2,5 @@
 here=$(dirname "$0")
 
 mkdir -p packages
-if [ -z ${GITHUB_PAT+x} ]; then
-    if [ ! -f $PWD/github_token ]; then
-        echo "Please go to your GitHub account, click Developer Settings, and generate"
-        echo "a new access token with full access to your private repos. Save this"
-        echo "token in a file named 'github_token' in the root of this repo."
-        exit 1;
-    fi
-    export GITHUB_PAT=$(<$PWD/github_token)
-fi
 export R_LIBS_USER="packages"
 $here/bootstrap.R


### PR DESCRIPTION
Also means no longer need to deploy with github_pat to the server: https://github.com/mrc-ide/shiny_dide/pull/8