### PR TITLE
I191 - Add download button for accessing PDF of plots and excel/csvs of model run tabular outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo ./scripts/install_geckodriver.sh
 ./scripts/test
 ```
 
-They should also run at https://travis-ci.org/mrc-ide/shiny90
+They should also run at https://travis-ci.com/mrc-ide/shiny90
 
 # Sample files
 Available on SharePoint [here](https://imperiallondon-my.sharepoint.com/:f:/r/personal/epidem_ic_ac_uk/Documents/UNAIDS%20Ref%20Group%20Shared%20Drive/Ref%20Group%20Meetings/Meetings%202018/first%2090%20workshop%20-%20Wisbech%20August%202018?csf=1&e=MFospr)

--- a/app.R
+++ b/app.R
@@ -14,6 +14,7 @@ source("src/helpers.R")
 
 # Server (alphabetical)
 source("src/server/data_tables.R")
+source("src/server/downloads.R")
 source("src/server/model_outputs.R")
 source("src/server/model_run.R")
 source("src/server/plot_inputs.R")

--- a/package_list.txt
+++ b/package_list.txt
@@ -12,4 +12,5 @@ memoise
 magrittr
 first90
 shinycssloaders
+writexl
 zip

--- a/package_sources.txt
+++ b/package_sources.txt
@@ -1,2 +1,1 @@
 mrc-ide/first90release
-andrewsali/shinycssloaders

--- a/scripts/bootstrap.R
+++ b/scripts/bootstrap.R
@@ -16,6 +16,7 @@ install.packages("rhandsontable")
 install.packages("data.table")
 install.packages("ggplot2")
 install.packages("memoise")
+install.packages("writexl")
 install.packages("zip")
 
 devtools::install_github('andrewsali/shinycssloaders')

--- a/scripts/bootstrap.R
+++ b/scripts/bootstrap.R
@@ -19,5 +19,5 @@ install.packages("memoise")
 install.packages("writexl")
 install.packages("zip")
 
-devtools::install_github('andrewsali/shinycssloaders')
+install.packages('shinycssloaders')
 devtools::install_github("mrc-ide/first90release")

--- a/src/server.R
+++ b/src/server.R
@@ -31,6 +31,7 @@ server <- function(input, output, session) {
     modelRunState <- modelRun(input, output, loadState$modelRunState, spectrumFilesState, surveyAndProgramData)
 
     handleSave(output, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState)
+    handleDownloads(input, output, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState)
     enableNavLinks(input, output, spectrumFilesState, modelRunState, surveyAndProgramData)
 
 

--- a/src/server.R
+++ b/src/server.R
@@ -31,7 +31,7 @@ server <- function(input, output, session) {
     modelRunState <- modelRun(input, output, loadState$modelRunState, spectrumFilesState, surveyAndProgramData)
 
     handleSave(output, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState)
-    handleDownloads(input, output, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState)
+    handleDownloads(output, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState)
     enableNavLinks(input, output, spectrumFilesState, modelRunState, surveyAndProgramData)
 
 

--- a/src/server/downloads.R
+++ b/src/server/downloads.R
@@ -1,6 +1,6 @@
-handleDownloads <- function(input, output, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState) {
+handleDownloads <- function(output, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState) {
   output$plotsDownload <- downloadPlots(workingSet, spectrumFilesState, surveyAndProgramData, modelRunState)
-  output$tablesDownload <- downloadTables(input, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState)
+  output$tablesDownload <- downloadTables(workingSet, spectrumFilesState, surveyAndProgramData, modelRunState)
 }
 
 downloadPlots <- function(workingSet, spectrumFilesState, surveyAndProgramData, modelRunState) {
@@ -18,7 +18,7 @@ downloadPlots <- function(workingSet, spectrumFilesState, surveyAndProgramData, 
   )
 }
 
-downloadTables <- function(input, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState) {
+downloadTables <- function(workingSet, spectrumFilesState, surveyAndProgramData, modelRunState) {
   
   shiny::downloadHandler(
     filename = function() {
@@ -27,7 +27,7 @@ downloadTables <- function(input, workingSet, spectrumFilesState, surveyAndProgr
     },
     contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     content = function(file) {
-      writeTablesForDownload(input, workingSet, spectrumFilesState, surveyAndProgramData,
+      writeTablesForDownload(workingSet, spectrumFilesState, surveyAndProgramData,
                              modelRunState, readmeTemplate, file)
     }
   )
@@ -86,12 +86,23 @@ writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgr
   }
 }
 
-writeTablesForDownload <- function(input, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState, readmeTemplate, path) {
+writeTablesForDownload <- function(workingSet, spectrumFilesState, surveyAndProgramData, modelRunState, readmeTemplate, path) {
+  params <- list(
+    aware_sex = sex_options(),
+    aware_agegr = agegr_options(),
+    nbaware_sex = sex_options(),
+    nbaware_agegr = agegr_options(),
+    art_coverage_sex = sex_options(),
+    ever_test_status = hiv_status_options(),
+    ever_test_sex = sex_options(),
+    ever_test_agegr = agegr_options()
+  )
+    
   sheets <- list(
-    "Knowledge of status (%)" = getTableAware(input)(modelRunState),
-    "Knowledge of status (absolute)" = getTableNbAware(input)(modelRunState),
-    "ART coverage" = getTableArtCoverage(input)(modelRunState),
-    "Proportion ever tested" = getTableEverTested(input)(modelRunState),
+    "Knowledge of status (%)" = getTableAware(params)(modelRunState),
+    "Knowledge of status (absolute)" = getTableNbAware(params)(modelRunState),
+    "ART coverage" = getTableArtCoverage(params)(modelRunState),
+    "Proportion ever tested" = getTableEverTested(params)(modelRunState),
     "Estimated parameters" = first90::optimized_par(modelRunState$optim),
     "Pregnant women" = first90::tab_out_pregprev(modelRunState$mod, modelRunState$fp)
   )

--- a/src/server/downloads.R
+++ b/src/server/downloads.R
@@ -36,18 +36,8 @@ downloadTables <- function(input, workingSet, spectrumFilesState, surveyAndProgr
 writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgramData, modelRunState, readmeTemplate, path) {
   pdf(file = path)
   on.exit(dev.off())
-  if (spectrumFilesState$anyDataPop()) {
-    first90::plot_pjnz_pop(spectrumFilesState$pjnz_summary())
-  }
-  if (spectrumFilesState$anyDataPlhiv()) {
-    first90::plot_pjnz_plhiv(spectrumFilesState$pjnz_summary())
-  }
-  if (spectrumFilesState$anyDataPrv()) {
-    first90::plot_pjnz_prv(spectrumFilesState$pjnz_summary())
-  }
-  if (spectrumFilesState$anyDataInc()) {
-    first90::plot_pjnz_inc(spectrumFilesState$pjnz_summary())
-  }
+  layout(matrix(seq_len(4), ncol = 2, byrow = TRUE))
+  on.exit(layout(1), add = TRUE)
   if (surveyAndProgramData$anyProgramDataTot()) {
     first90::plot_input_tot(surveyAndProgramData$program_data, spectrumFilesState$combinedData())
   }
@@ -59,6 +49,18 @@ writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgr
   }
   if (surveyAndProgramData$anyProgramDataAncPos()) {
     first90::plot_input_ancpos(surveyAndProgramData$program_data, spectrumFilesState$combinedData())
+  }
+  if (spectrumFilesState$anyDataPrv()) {
+    first90::plot_pjnz_prv(spectrumFilesState$pjnz_summary())
+  }
+  if (spectrumFilesState$anyDataInc()) {
+    first90::plot_pjnz_inc(spectrumFilesState$pjnz_summary())
+  }
+  if (spectrumFilesState$anyDataPop()) {
+    first90::plot_pjnz_pop(spectrumFilesState$pjnz_summary())
+  }
+  if (spectrumFilesState$anyDataPlhiv()) {
+    first90::plot_pjnz_plhiv(spectrumFilesState$pjnz_summary())
   }
   if (modelRunState$state == "converged" && !is.null(modelRunState$optim)) {
     mod <- modelRunState$mod
@@ -77,9 +79,10 @@ writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgr
     first90::plot_out_90s(mod, fp, likdat, country, out_evertest, surveyAsDataTable, simul)
     first90::plot_out_evertest_fbyage(mod, fp, likdat, country, surveyAsDataTable, out_evertest, simul)
     first90::plot_out_evertest_mbyage(mod, fp, likdat, country, surveyAsDataTable, out_evertest, simul)
-    first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2018)
+    
     first90::plot_retest_test_neg(mod, fp, likdat, country)
     first90::plot_retest_test_pos(mod, fp, likdat, country)
+    first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2018)
   }
 }
 

--- a/src/server/downloads.R
+++ b/src/server/downloads.R
@@ -1,0 +1,96 @@
+handleDownloads <- function(input, output, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState) {
+  output$plotsDownload <- downloadPlots(workingSet, spectrumFilesState, surveyAndProgramData, modelRunState)
+  output$tablesDownload <- downloadTables(input, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState)
+}
+
+downloadPlots <- function(workingSet, spectrumFilesState, surveyAndProgramData, modelRunState) {
+  
+  shiny::downloadHandler(
+    filename = function() {
+      name <- gsub(" ", "", workingSet$name())
+      glue::glue("{name}_plots.pdf")
+    },
+    contentType = "application/pdf",
+    content = function(file) {
+      writePlotsForDownload(workingSet, spectrumFilesState, surveyAndProgramData,
+                            modelRunState, readmeTemplate, file)
+    }
+  )
+}
+
+downloadTables <- function(input, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState) {
+  
+  shiny::downloadHandler(
+    filename = function() {
+      name <- gsub(" ", "", workingSet$name())
+      glue::glue("{name}_tables.xlsx")
+    },
+    contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    content = function(file) {
+      writeTablesForDownload(input, workingSet, spectrumFilesState, surveyAndProgramData,
+                             modelRunState, readmeTemplate, file)
+    }
+  )
+}
+
+writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgramData, modelRunState, readmeTemplate, path) {
+  pdf(file = path)
+  on.exit(dev.off())
+  if (spectrumFilesState$anyDataPop()) {
+    first90::plot_pjnz_pop(spectrumFilesState$pjnz_summary())
+  }
+  if (spectrumFilesState$anyDataPlhiv()) {
+    first90::plot_pjnz_plhiv(spectrumFilesState$pjnz_summary())
+  }
+  if (spectrumFilesState$anyDataPrv()) {
+    first90::plot_pjnz_prv(spectrumFilesState$pjnz_summary())
+  }
+  if (spectrumFilesState$anyDataInc()) {
+    first90::plot_pjnz_inc(spectrumFilesState$pjnz_summary())
+  }
+  if (surveyAndProgramData$anyProgramDataTot()) {
+    first90::plot_input_tot(surveyAndProgramData$program_data, spectrumFilesState$combinedData())
+  }
+  if (surveyAndProgramData$anyProgramDataTotPos()) {
+    first90::plot_input_totpos(surveyAndProgramData$program_data, spectrumFilesState$combinedData())
+  }
+  if (surveyAndProgramData$anyProgramDataAnc()) {
+    first90::plot_input_anctot(surveyAndProgramData$program_data, spectrumFilesState$combinedData())
+  }
+  if (surveyAndProgramData$anyProgramDataAncPos()) {
+    first90::plot_input_ancpos(surveyAndProgramData$program_data, spectrumFilesState$combinedData())
+  }
+  if (modelRunState$state == "converged" && !is.null(modelRunState$optim)) {
+    mod <- modelRunState$mod
+    fp <- modelRunState$fp
+    likdat <- modelRunState$likelihood()
+    country <- spectrumFilesState$countryAndRegionName()
+    out_evertest <- first90::get_out_evertest(mod, fp)
+    simul <- modelRunState$simul
+    surveyAsDataTable <- modelRunState$surveyAsDataTable()
+    
+    first90::plot_out_nbtest(mod, fp, likdat, country, simul)
+    first90::plot_out_nbpostest(mod, fp, likdat, country, simul)
+    first90::plot_out_evertestneg(mod, fp, likdat, country, surveyAsDataTable, out_evertest, simul)
+    first90::plot_out_evertestpos(mod, fp, likdat, country, surveyAsDataTable, out_evertest, simul)
+    first90::plot_out_evertest(mod, fp, likdat, country, surveyAsDataTable, out_evertest, simul)
+    first90::plot_out_90s(mod, fp, likdat, country, out_evertest, surveyAsDataTable, simul)
+    first90::plot_out_evertest_fbyage(mod, fp, likdat, country, surveyAsDataTable, out_evertest, simul)
+    first90::plot_out_evertest_mbyage(mod, fp, likdat, country, surveyAsDataTable, out_evertest, simul)
+    first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2018)
+    first90::plot_retest_test_neg(mod, fp, likdat, country)
+    first90::plot_retest_test_pos(mod, fp, likdat, country)
+  }
+}
+
+writeTablesForDownload <- function(input, workingSet, spectrumFilesState, surveyAndProgramData, modelRunState, readmeTemplate, path) {
+  sheets <- list(
+    "Knowledge of status (%)" = getTableAware(input)(modelRunState),
+    "Knowledge of status (absolute)" = getTableNbAware(input)(modelRunState),
+    "ART coverage" = getTableArtCoverage(input)(modelRunState),
+    "Proportion ever tested" = getTableEverTested(input)(modelRunState),
+    "Estimated parameters" = first90::optimized_par(modelRunState$optim),
+    "Pregnant women" = first90::tab_out_pregprev(modelRunState$mod, modelRunState$fp)
+  )
+  writexl::write_xlsx(sheets, path = path)
+}

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -142,35 +142,50 @@ renderOutputs <- function(input, output, state, spectrumFilesState) {
     })
 
     # Render tables of results
-    output$outputs_table_ever_tested <- renderModelResultsTable(state, function(state) {
+    output$outputs_table_ever_tested <- renderModelResultsTable(state, getTableEverTested(input))
+    output$outputs_table_aware <- renderModelResultsTable(state, getTableAware(input))
+    output$outputs_table_nbaware <- renderModelResultsTable(state, getTableNbAware(input))
+    output$outputs_table_art_coverage <- renderModelResultsTable(state, getTableArtCoverage(input))
+}
 
-        rbindlist(lapply(input$ever_test_status, function(status) {
-            rbindlist(lapply(input$ever_test_sex, function(sex) {
-                rbindlist(lapply(input$ever_test_agegr, function(age) {
-                    first90::tab_out_evertest(state$mod, state$fp, age_grp = age, simul = state$simul, hiv = status, gender = sex)
-                }))
-            }))
+getTableEverTested <- function(input) {
+  func <- function(state) {
+    rbindlist(lapply(input$ever_test_status, function(status) {
+      rbindlist(lapply(input$ever_test_sex, function(sex) {
+        rbindlist(lapply(input$ever_test_agegr, function(age) {
+          first90::tab_out_evertest(state$mod, state$fp, age_grp = age, simul = state$simul, hiv = status, gender = sex)
         }))
-    })
-    output$outputs_table_aware <- renderModelResultsTable(state, function(state) {
-        rbindlist(lapply(input$aware_sex, function(sex) {
-            rbindlist(lapply(input$aware_agegr, function(age) {
-                first90::tab_out_aware(state$mod, state$fp, simul = state$simul, age_grp = age, gender = sex)
-            }))
-        }))
-    })
-    output$outputs_table_nbaware <- renderModelResultsTable(state, function(state) {
-        rbindlist(lapply(input$nbaware_sex, function(sex) {
-            rbindlist(lapply(input$nbaware_agegr, function(age) {
-                first90::tab_out_nbaware(state$mod, state$fp, age_grp = age, gender = sex)
-            }))
-        }))
-    })
-    output$outputs_table_art_coverage <- renderModelResultsTable(state, function(state) {
-        rbindlist(lapply(input$art_coverage_sex, function(sex) {
-                first90::tab_out_artcov(state$mod, state$fp, gender = sex)
-        }))
-    })
+      }))
+    }))
+  }
+}
+
+getTableAware <- function(input) {
+  func <- function(state) {
+    rbindlist(lapply(input$aware_sex, function(sex) {
+      rbindlist(lapply(input$aware_agegr, function(age) {
+        first90::tab_out_aware(state$mod, state$fp, simul = state$simul, age_grp = age, gender = sex)
+      }))
+    }))
+  }
+}
+
+getTableNbAware <- function(input) {
+  func <- function(state) {
+    rbindlist(lapply(input$nbaware_sex, function(sex) {
+      rbindlist(lapply(input$nbaware_agegr, function(age) {
+        first90::tab_out_nbaware(state$mod, state$fp, age_grp = age, gender = sex)
+      }))
+    }))
+  }
+}
+
+getTableArtCoverage <- function(input) {
+  func <- function(state) {
+    rbindlist(lapply(input$art_coverage_sex, function(sex) {
+      first90::tab_out_artcov(state$mod, state$fp, gender = sex)
+    }))
+  }
 }
 
 invalidateOutputsWhenInputsChange <- function(state, surveyAndProgramData, spectrumFilesState) {

--- a/src/tests/helpers.R
+++ b/src/tests/helpers.R
@@ -13,7 +13,9 @@ profile <- RSelenium::makeFirefoxProfile(list(
     # This is an enum, '2' means use the value in the next parameter
     "browser.download.dir" = downloadedFiles,
     "browser.download.folderList" = 2L,
-    "browser.helperApps.neverAsk.saveToDisk" = "application/zip;text/csv"
+    "browser.helperApps.neverAsk.saveToDisk" = 
+      "application/zip;text/csv;application/pdf;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "pdfjs.disabled" = TRUE
 ))
 wd <- RSelenium::remoteDriver(
     browserName = "firefox",

--- a/src/tests/testthat/testDownloads.R
+++ b/src/tests/testthat/testDownloads.R
@@ -1,0 +1,21 @@
+library(methods)
+testthat::context("downloads")
+
+testthat::test_that("model run outputs can be downloaded", {
+  uploadSpectrumFileAndSwitchTab("Upload survey data")
+  uploadFile(wd, filename = "fakesurvey_malawi.csv", inputId="#surveyData")
+  
+  switchTab(wd, "Run model")
+  runModel()
+  
+  plots_download = wd$findElement("css", inActivePane("#plotsDownload"))
+  expectTextEqual("Download plots as PDF", plots_download)
+  downloadFileFromLink(plots_download, "Malawi_plots.pdf")
+  
+  tables_download = wd$findElement("css", inActivePane("#tablesDownload"))
+  expectTextEqual("Download tables as XLSX", tables_download)
+  downloadFileFromLink(tables_download, "Malawi_tables.xlsx")
+  
+  removeFile("Malawi_plots.pdf")
+  removeFile("Malawi_tables.xlsx")
+})

--- a/src/ui/input_panels.R
+++ b/src/ui/input_panels.R
@@ -92,7 +92,8 @@ panelReviewInput <- function() {
                         and review your results, you can re-upload this file and resume where you left off.")
         ),
         shiny::div("", class="save-button",
-            downloadButtonWithCustomClass("digestDownload3", "Save your work")
+            downloadButtonWithCustomClass("digestDownload3", "Save your work", 
+                                          font_awesome_icon = "download")
         ),
         shiny::conditionalPanel(
             condition = "output.invalidProgramData",

--- a/src/ui/model_outputs_panel.R
+++ b/src/ui/model_outputs_panel.R
@@ -10,8 +10,19 @@ panelModelOutputs <- function() {
                                 into Spectrum. This will download a file containing your input data and results. You can 
                                 also re-upload this file later to view your results again and change your input data.")
                 ),
-                shiny::div("", class="mb-5 save-button",
-                    downloadButtonWithCustomClass("digestDownload2", "Download shiny90 outputs for Spectrum")
+                shiny::div("", class="mb-3 save-button",
+                    downloadButtonWithCustomClass("digestDownload2", "Download shiny90 outputs for Spectrum", 
+                                                  font_awesome_icon = "download")
+                ),
+                shiny::div("", class="mb-3 download-text",
+                    shiny::span("You can download all generated plots as a PDF or download all output tables 
+                                 as an XLSX.")
+                ),
+                shiny::div("", class="mb-5 download-buttons",
+                    downloadButtonWithCustomClass("plotsDownload", "Download plots as PDF", 
+                                                  emphasis = "medium", font_awesome_icon = "chart-area"),
+                    downloadButtonWithCustomClass("tablesDownload", "Download tables as XLSX", 
+                                                  emphasis = "medium", font_awesome_icon = "table")
                 ),
                 shiny::tabsetPanel(
                     shiny::tabPanel("Figures",

--- a/src/ui/model_outputs_panel.R
+++ b/src/ui/model_outputs_panel.R
@@ -77,7 +77,7 @@ select_options <- function(id, includeStatus = TRUE, includeAge = TRUE) {
 
     if (includeStatus){
         status <- shiny::selectizeInput(
-                        paste0(id, '_status'),'HIV Status', choices = c("positive", 'negative','all'),
+                        paste0(id, '_status'),'HIV Status', choices = hiv_status_options(),
                         multiple = TRUE,
                         selected = "positive")
     }
@@ -86,7 +86,7 @@ select_options <- function(id, includeStatus = TRUE, includeAge = TRUE) {
     }
     if (includeAge){
         age <- shiny::selectizeInput(
-                        paste0(id, '_agegr'), 'Age group', choices = c("15-24", '25-34','35-49', '15-49', "15+"),
+                        paste0(id, '_agegr'), 'Age group', choices = agegr_options(),
                         multiple = TRUE,
                         selected = "15+")
     }
@@ -94,11 +94,23 @@ select_options <- function(id, includeStatus = TRUE, includeAge = TRUE) {
         age <- NULL
     }
     list(shiny::selectizeInput(
-            paste0(id, '_sex'), 'Sex', choices = c("both", "male", "female"),
+            paste0(id, '_sex'), 'Sex', choices = sex_options(),
             multiple = TRUE,
             selected = "both"
         ),
         age,
         status
     )
+}
+
+sex_options <- function() {
+  c("both", "male", "female")
+}
+
+agegr_options <- function() {
+  c("15-24", '25-34','35-49', '15-49', "15+")
+}
+
+hiv_status_options <- function() {
+  c("positive", 'negative','all')
 }

--- a/src/ui/ui_helpers.R
+++ b/src/ui/ui_helpers.R
@@ -23,10 +23,17 @@ actionButtonWithCustomClass <- function (inputId, label, ..., cssClasses = NULL,
         list(label), ...)
 }
 
-downloadButtonWithCustomClass <- function (inputId, label, ..., cssClasses = NULL, type = "button") {
+downloadButtonWithCustomClass <- function (inputId, label, ..., cssClasses = NULL, type = "button", emphasis = "high", font_awesome_icon = NULL) {
+  if (emphasis == "high") {
+    classes <- paste("btn btn-default btn-red btn-lg btn-success shiny-download-link", cssClasses)
+  } else if (emphasis == "medium") {
+    classes <- paste("btn btn-default shiny-download-link", cssClasses)
+  } else {
+    classes <- cssClasses
+  }
   value <- shiny::restoreInput(id = inputId, default = NULL)
-  shiny::tags$a(id = inputId, label, href = "",
-                class = paste("btn btn-default btn-red btn-lg btn-success shiny-download-link", cssClasses),
+  icon <- shiny::icon(font_awesome_icon)
+  shiny::tags$a(id = inputId, icon, label, href = "", class = classes, 
                 download = NA, target = "_blank", ...)
 }
 


### PR DESCRIPTION
This pull request will

* Add 2 new buttons to model run page, one to download plots and another to download an excel file containing each of the model output tables
* Also adds icons to the 2 "Save your work" buttons to better distinguish functionality of different buttons
* Fix a small typo in README

Couple of things in particular which I want to discuss - **EDIT** All of the issues below were a side effect of the JS errors in the page being caused by broken development version of shinycssloaders package they now work fine
* When downloading plots when programmatic data has been uploaded the plots include "Total no of tests performed", "Total No of HIV+ tests", "Total no of HIV tests performed at ANC", "Total no of HIV+ tests at ANC" however not all of these are shown in the "review input data" tab. Is that the intended behaviour? Should I be excluding some of these plots here? 
* There also seems to be several UI issues which I'm experiencing which exist on master too. I wonder if you've seen any of these? 
   * I can't seem to successfully continue from an uploaded ".zip.shiny90" file. It looks to complete the upload but then UI hangs on the upload pop-up. 
   * Uploading a "PJNZ" file also seems odd, behaviour to successfully do this is go to "Upload Spectrum file(s)" tab. Change "Use:" combobox to ".DP and .PJN", change back to ".PJNZ" click browse, change file extension to select from all files. Select a PJNZ file to upload. This won't work but the UI updates to prompt you to "Choose PJNZ file(s)", click browse again and behaviour is as expected. 
It looks like the UI isn't updating when the "Use:" combobox is changes.
   * I have to click buttons on the home page twice for action to take effect (once to focus and then once to do the action)