### PR TITLE
point shiny90 to first90@2020update branch

### DIFF
--- a/package_sources.txt
+++ b/package_sources.txt
@@ -1,1 +1,1 @@
-mrc-ide/first90release
+mrc-ide/first90release@2020update

--- a/package_sources.txt
+++ b/package_sources.txt
@@ -1,1 +1,2 @@
 mrc-ide/first90release
+rstudio/shiny

--- a/provision.yml
+++ b/provision.yml
@@ -1,7 +1,6 @@
 packages:
   - tidyr
   - numDeriv
-  - shiny
   - shinyjs
   - glue
   - devtools
@@ -18,3 +17,4 @@ packages:
 package_sources:
   github:
   - mrc-ide/first90release
+  - rstudio/shiny

--- a/provision.yml
+++ b/provision.yml
@@ -17,4 +17,4 @@ packages:
   - zip
 package_sources:
   github:
-  - mrc-ide/first90release
+  - mrc-ide/first90release@2020update

--- a/scripts/bootstrap.R
+++ b/scripts/bootstrap.R
@@ -7,7 +7,6 @@ local({r <- getOption("repos")
 
 install.packages("tidyr")
 install.packages("numDeriv")
-install.packages("shiny")
 install.packages("shinyjs")
 install.packages("glue")
 install.packages("devtools")
@@ -21,3 +20,4 @@ install.packages("zip")
 
 install.packages('shinycssloaders')
 devtools::install_github("mrc-ide/first90release")
+devtools::install_github("rstudio/shiny")

--- a/scripts/bootstrap.R
+++ b/scripts/bootstrap.R
@@ -20,4 +20,4 @@ install.packages("writexl")
 install.packages("zip")
 
 install.packages('shinycssloaders')
-devtools::install_github("mrc-ide/first90release")
+devtools::install_github("mrc-ide/first90release@2020update")


### PR DESCRIPTION
Hi,

@m-maheu-giroux has made some updates to first90release for 2020:
* Extend the model period 2 more years.
* Add two additional columns to the `model_outputs/spectrum_output.csv`.

These are on mrc-ide/first90release#13. 

These updates do not involve any user interface changes. The purpose for this PR points Shiny90 to first90release@2020update branch to check.

But if this passes, no need to merge this branch I don't think, rather we should merge mrc-ide/first90release#13  to master and then redeploy the current Shiny90 using that package (first90 v.13).

Thanks,
Jeff