### PR TITLE
peg to version tag v1.3.2

### DIFF
--- a/package_sources.txt
+++ b/package_sources.txt
@@ -1,2 +1,2 @@
-mrc-ide/first90release@2020update
+mrc-ide/first90release@v1.3.2
 rstudio/shiny

--- a/provision.yml
+++ b/provision.yml
@@ -16,6 +16,6 @@ packages:
   - zip
 package_sources:
   github:
-  - mrc-ide/first90release@2020update
+  - mrc-ide/first90release@v1.3.2
   - rstudio/shiny
 

--- a/scripts/bootstrap.R
+++ b/scripts/bootstrap.R
@@ -19,5 +19,5 @@ install.packages("writexl")
 install.packages("zip")
 
 install.packages('shinycssloaders')
-devtools::install_github("mrc-ide/first90release@2020update")
+devtools::install_github("mrc-ide/first90release@v1.3.2")
 devtools::install_github("rstudio/shiny")


### PR DESCRIPTION
I'm adding version number tags to first90 so that shiny90 can reference specific version number of first90 package.  Is this to do that?

Can you please merge and redeploy?

Thanks,
Jeff