### PR TITLE
don't call layout again

### DIFF
--- a/src/server/downloads.R
+++ b/src/server/downloads.R
@@ -37,7 +37,6 @@ writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgr
   pdf(file = path)
   on.exit(dev.off())
   layout(matrix(seq_len(4), ncol = 2, byrow = TRUE))
-  on.exit(layout(1), add = TRUE)
   if (surveyAndProgramData$anyProgramDataTot()) {
     first90::plot_input_tot(surveyAndProgramData$program_data, spectrumFilesState$combinedData())
   }
@@ -70,7 +69,7 @@ writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgr
     out_evertest <- first90::get_out_evertest(mod, fp)
     simul <- modelRunState$simul
     surveyAsDataTable <- modelRunState$surveyAsDataTable()
-    
+
     first90::plot_out_nbtest(mod, fp, likdat, country, simul)
     first90::plot_out_nbpostest(mod, fp, likdat, country, simul)
     first90::plot_out_evertestneg(mod, fp, likdat, country, surveyAsDataTable, out_evertest, simul)
@@ -79,7 +78,7 @@ writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgr
     first90::plot_out_90s(mod, fp, likdat, country, out_evertest, surveyAsDataTable, simul)
     first90::plot_out_evertest_fbyage(mod, fp, likdat, country, surveyAsDataTable, out_evertest, simul)
     first90::plot_out_evertest_mbyage(mod, fp, likdat, country, surveyAsDataTable, out_evertest, simul)
-    
+
     first90::plot_retest_test_neg(mod, fp, likdat, country)
     first90::plot_retest_test_pos(mod, fp, likdat, country)
     first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2018)


### PR DESCRIPTION
This fixes a bug when downloading plots as pdf:

```
Warning: Error in <Anonymous>: cannot open file 'Rplots.pdf'
  [No stack trace available]
```

Calling `layout(1)` on exit from the function was generating a new pdf device with the default filename ("Rplots.pdf") in the current working directory which the app does not have write permissions to. But I can't see why this was being called.