### PR TITLE
pin to first90release@v1.4.1

### DIFF
--- a/package_sources.txt
+++ b/package_sources.txt
@@ -1,2 +1,2 @@
-mrc-ide/first90release@v1.4.0
+mrc-ide/first90release@v1.4.1
 rstudio/shiny

--- a/provision.yml
+++ b/provision.yml
@@ -16,6 +16,6 @@ packages:
   - zip
 package_sources:
   github:
-  - mrc-ide/first90release@v1.4.0
+  - mrc-ide/first90release@v1.4.1
   - rstudio/shiny
 

--- a/scripts/bootstrap.R
+++ b/scripts/bootstrap.R
@@ -19,5 +19,5 @@ install.packages("writexl")
 install.packages("zip")
 
 install.packages('shinycssloaders')
-devtools::install_github("mrc-ide/first90release@v1.4.0")
+devtools::install_github("mrc-ide/first90release@v1.4.1")
 devtools::install_github("rstudio/shiny")


### PR DESCRIPTION
Update shiny90 to use first90 v1.4.1.  The plots that were missing the additional year are fixed in that version now.

I deleted the previous tag (v1.4.0) to avoid any inadvertent use of that tagged version.

Thanks,
Jeff