### PR TITLE
first90 v1.5.0

### DIFF
--- a/package_sources.txt
+++ b/package_sources.txt
@@ -1,2 +1,2 @@
-mrc-ide/first90release@v1.4.1
+mrc-ide/first90release@v1.5.0
 rstudio/shiny

--- a/provision.yml
+++ b/provision.yml
@@ -16,6 +16,6 @@ packages:
   - zip
 package_sources:
   github:
-  - mrc-ide/first90release@v1.4.1
+  - mrc-ide/first90release@v1.5.0
   - rstudio/shiny
 

--- a/scripts/bootstrap.R
+++ b/scripts/bootstrap.R
@@ -19,5 +19,5 @@ install.packages("writexl")
 install.packages("zip")
 
 install.packages('shinycssloaders')
-devtools::install_github("mrc-ide/first90release@v1.4.1")
+devtools::install_github("mrc-ide/first90release@v1.5.0")
 devtools::install_github("rstudio/shiny")

--- a/src/server/spectrum_files.R
+++ b/src/server/spectrum_files.R
@@ -9,7 +9,6 @@ spectrumFiles <- function(input, output, state) {
         if (state$anyDataSets()) {
             pjnz_in <- lapply(state$dataSets, function(x) {x$data})
             fp <- first90::prepare_inputs_from_extracts(pjnz_in)
-            fp$popadjust <- FALSE
 
             fp
         }


### PR DESCRIPTION
This PR:

* Updates Shiny90 to first90 v1.5.0 for 2022 UNAIDS estimates.
* Removes setting the `popadjust = FALSE` argument by Shiny90. This argument is now read from the PJNZ by first90.

I haven't tried to run test suite locally yet and I see that we have removed the Github testing. Are one of you able to try running the tests locally?  I think that Rob ran them locally last year.