### PR TITLE
Fix branch name for shiny download

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -17,5 +17,5 @@ packages:
 package_sources:
   github:
   - mrc-ide/first90release@v1.5.0
-  - rstudio/shiny
+  - rstudio/shiny@main
 


### PR DESCRIPTION
It's quite likely that we can use cran shiny now I expect, as it's pretty recent (October) but if we want to track development shiny then we need to target the `main` branch now as the current downloading code assumed `master`