### PR TITLE
update input table and plot from 2018 to 2021

### DIFF
--- a/src/server/downloads.R
+++ b/src/server/downloads.R
@@ -81,7 +81,7 @@ writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgr
 
     first90::plot_retest_test_neg(mod, fp, likdat, country)
     first90::plot_retest_test_pos(mod, fp, likdat, country)
-    first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2018)
+    first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2021)
   }
 }
 

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -258,7 +258,7 @@ plotModelRunResults <- function(output, surveyAsDataTable, likdat, fp, mod, coun
     })
 
     output$outputs_prv_pos_yld <- shiny::renderPlot({
-        first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2018)
+        first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2021)
     })
 
     output$outputs_retest_neg <- shiny::renderPlot({

--- a/src/server/survey_and_program_data.R
+++ b/src/server/survey_and_program_data.R
@@ -126,7 +126,7 @@ createEmptySurveyData <- function(countryAndRegionName) {
 
 createEmptyProgramData <- function(countryAndRegionName) {
     data.frame(country = countryAndRegionName,
-                year = 2010:2018,
+                year = 2010:2021,
                 sex = 'both',
                 tot = NA_integer_,
                 totpos = NA_integer_,


### PR DESCRIPTION
This makes a couple of cosmetic changes: 

* Updates the default programme data input data table to show rows through 2021 instead of 2018.
* Updates one of the plot outputs to go through 2021 instead of 2018.

These are probably not so consequential because most users upload CSVs for the input data rather than enter in the table. But I think a nice cosmetic update for us to make.

Thanks,
Jeff