### PR TITLE
First90 v1.5.1

### DIFF
--- a/package_sources.txt
+++ b/package_sources.txt
@@ -1,2 +1,2 @@
-mrc-ide/first90release@v1.5.0
+mrc-ide/first90release@v1.5.1
 rstudio/shiny

--- a/provision.yml
+++ b/provision.yml
@@ -16,6 +16,6 @@ packages:
   - zip
 package_sources:
   github:
-  - mrc-ide/first90release@v1.5.0
+  - mrc-ide/first90release@v1.5.1
   - rstudio/shiny
 

--- a/scripts/bootstrap.R
+++ b/scripts/bootstrap.R
@@ -19,5 +19,5 @@ install.packages("writexl")
 install.packages("zip")
 
 install.packages('shinycssloaders')
-devtools::install_github("mrc-ide/first90release@v1.5.0")
+devtools::install_github("mrc-ide/first90release@v1.5.1")
 devtools::install_github("rstudio/shiny")

--- a/src/server/downloads.R
+++ b/src/server/downloads.R
@@ -81,7 +81,7 @@ writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgr
 
     first90::plot_retest_test_neg(mod, fp, likdat, country)
     first90::plot_retest_test_pos(mod, fp, likdat, country)
-    first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2018)
+    first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2021)
   }
 }
 

--- a/src/server/model_run.R
+++ b/src/server/model_run.R
@@ -258,7 +258,7 @@ plotModelRunResults <- function(output, surveyAsDataTable, likdat, fp, mod, coun
     })
 
     output$outputs_prv_pos_yld <- shiny::renderPlot({
-        first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2018)
+        first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2021)
     })
 
     output$outputs_retest_neg <- shiny::renderPlot({

--- a/src/server/survey_and_program_data.R
+++ b/src/server/survey_and_program_data.R
@@ -126,7 +126,7 @@ createEmptySurveyData <- function(countryAndRegionName) {
 
 createEmptyProgramData <- function(countryAndRegionName) {
     data.frame(country = countryAndRegionName,
-                year = 2010:2018,
+                year = 2010:2021,
                 sex = 'both',
                 tot = NA_integer_,
                 totpos = NA_integer_,


### PR DESCRIPTION
This PR changes: 

* pin to first90 v1.5.1 -- which extends a few output plots and tables to 2021 which were missed in the v1.5.0 update.
* Updates the default programme data input data table to show rows through 2021 instead of 2018.
* Updates one of the plot outputs to go through 2021 instead of 2018.