### PR TITLE
pin to first90release@v1.5.2

### DIFF
--- a/package_sources.txt
+++ b/package_sources.txt
@@ -1,2 +1,2 @@
-mrc-ide/first90release@v1.5.1
+mrc-ide/first90release@v1.5.2
 rstudio/shiny

--- a/provision.yml
+++ b/provision.yml
@@ -16,6 +16,6 @@ packages:
   - zip
 package_sources:
   github:
-  - mrc-ide/first90release@v1.5.1
+  - mrc-ide/first90release@v1.5.2
   - rstudio/shiny@main
 

--- a/scripts/bootstrap.R
+++ b/scripts/bootstrap.R
@@ -19,5 +19,5 @@ install.packages("writexl")
 install.packages("zip")
 
 install.packages('shinycssloaders')
-devtools::install_github("mrc-ide/first90release@v1.5.1")
+devtools::install_github("mrc-ide/first90release@v1.5.2")
 devtools::install_github("rstudio/shiny")


### PR DESCRIPTION
Update the first90 package version to 1.5.2.

This is a very small update -- just updates the starting values for the optimiser to the median from the 2021 final results.