### PR TITLE
remove browser() in plot download sequence

### DIFF
--- a/src/server/downloads.R
+++ b/src/server/downloads.R
@@ -81,7 +81,6 @@ writePlotsForDownload <- function(workingSet, spectrumFilesState, surveyAndProgr
 
     first90::plot_retest_test_neg(mod, fp, likdat, country)
     first90::plot_retest_test_pos(mod, fp, likdat, country)
-    browser()
     first90::plot_prv_pos_yld(mod, fp, likdat, country, yr_pred = 2022)
   }
 }


### PR DESCRIPTION
Accidentally left a debug call in the code where 'download plots' is triggered.