### PR TITLE
Use current version of shiny

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -17,5 +17,3 @@ packages:
 package_sources:
   github:
   - mrc-ide/first90release@v1.6.6
-  - rstudio/shiny@main
-


### PR DESCRIPTION
With the upgrade to the shiny server, we won't want this version of shiny, and indeed this fails to compile for some reason I do not want to explore